### PR TITLE
Update README.md - Fix link to config object definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ module.exports = function resolver( packageName, options ) {
 };
 ```
 
-You can also check the [default resolver](https://github.com/cksource/mrgit/blob/master/lib/default-resolver.js) used by `mrgit` and [the config object definition](https://github.com/cksource/mrgit/blob/master/lib/utils/getconfig.js).
+You can also check the [default resolver](https://github.com/cksource/mrgit/blob/master/lib/default-resolver.js) used by `mrgit` and [the config object definition](https://github.com/cksource/mrgit/blob/master/lib/utils/getoptions.js).
 
 ### Cloning repositories on CI servers
 


### PR DESCRIPTION
Doc: Fix link to config object definition in README

Let me know if i should amend the commit message to follow the convention (using the above text), i just used the github ui.

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Type: Message. Closes #000.


