### PR TITLE
Allowed the "license-header" ESLint rule.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,12 @@ module.exports = {
 		node: true
 	},
 	rules: {
-		'no-console': 'off'
+		'no-console': 'off',
+		'ckeditor5-rules/license-header': [ 'error', { headerLines: [
+			'/**',
+			' * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.',
+			' * For licensing, see LICENSE.md.',
+			' */'
+		] } ]
 	}
 };

--- a/package.json
+++ b/package.json
@@ -1,77 +1,77 @@
 {
-  "name": "mrgit",
-  "version": "1.0.0",
-  "description": "A tool for managing projects build using multiple repositories.",
-  "keywords": [
-    "git",
-    "repository",
-    "submodule",
-    "package",
-    "multi-repository",
-    "multi-repo",
-    "lerna",
-    "yarn",
-    "workspaces"
-  ],
-  "main": "index.js",
-  "dependencies": {
-    "chalk": "^4.1.0",
-    "cli-table": "^0.3.1",
-    "generic-pool": "^3.7.1",
-    "meow": "^7.1.0",
-    "minimatch": "^3.0.4",
-    "minimist": "^1.2.5",
-    "minimist-options": "^4.1.0",
-    "shelljs": "^0.8.4",
-    "upath": "^1.2.0"
-  },
-  "devDependencies": {
-    "@ckeditor/ckeditor5-dev-env": "^28.1.1",
-    "chai": "^4.2.0",
-    "eslint": "^7.7.0",
-    "eslint-config-ckeditor5": "^3.0.0",
-    "husky": "^4.2.5",
-    "istanbul": "^0.4.5",
-    "lint-staged": "^10.2.11",
-    "mocha": "^8.1.1",
-    "mockery": "^2.1.0",
-    "sinon": "^9.0.3"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/cksource/mrgit.git"
-  },
-  "engines": {
-    "node": ">=12.0.0",
-    "npm": ">=5.7.1"
-  },
-  "author": "CKSource (http://cksource.com/)",
-  "license": "MIT",
-  "bugs": "https://github.com/cksource/mrgit/issues",
-  "homepage": "https://github.com/cksource/mrgit#readme",
-  "scripts": {
-    "test": "mocha tests --recursive",
-    "coverage": "istanbul cover _mocha tests -- --recursive",
-    "lint": "eslint --quiet '**/*.js'",
-    "changelog": "node ./scripts/changelog.js",
-    "release:bump-version": "node ./scripts/bump-version.js",
-    "release:publish": "node ./scripts/publish.js"
-  },
-  "bin": {
-    "mrgit": "./index.js"
-  },
-  "files": [
-    "index.js",
-    "lib"
-  ],
-  "lint-staged": {
-    "**/*.js": [
-      "eslint --quiet"
-    ]
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  }
+	"name": "mrgit",
+	"version": "1.0.0",
+	"description": "A tool for managing projects build using multiple repositories.",
+	"keywords": [
+		"git",
+		"repository",
+		"submodule",
+		"package",
+		"multi-repository",
+		"multi-repo",
+		"lerna",
+		"yarn",
+		"workspaces"
+	],
+	"main": "index.js",
+	"dependencies": {
+		"chalk": "^4.1.0",
+		"cli-table": "^0.3.1",
+		"generic-pool": "^3.7.1",
+		"meow": "^7.1.0",
+		"minimatch": "^3.0.4",
+		"minimist": "^1.2.5",
+		"minimist-options": "^4.1.0",
+		"shelljs": "^0.8.4",
+		"upath": "^1.2.0"
+	},
+	"devDependencies": {
+		"@ckeditor/ckeditor5-dev-env": "^28.1.1",
+		"chai": "^4.2.0",
+		"eslint": "^7.7.0",
+		"eslint-config-ckeditor5": "^4.0.0",
+		"husky": "^4.2.5",
+		"istanbul": "^0.4.5",
+		"lint-staged": "^10.2.11",
+		"mocha": "^8.1.1",
+		"mockery": "^2.1.0",
+		"sinon": "^9.0.3"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/cksource/mrgit.git"
+	},
+	"engines": {
+		"node": ">=12.0.0",
+		"npm": ">=5.7.1"
+	},
+	"author": "CKSource (http://cksource.com/)",
+	"license": "MIT",
+	"bugs": "https://github.com/cksource/mrgit/issues",
+	"homepage": "https://github.com/cksource/mrgit#readme",
+	"scripts": {
+		"test": "mocha tests --recursive",
+		"coverage": "istanbul cover _mocha tests -- --recursive",
+		"lint": "eslint --quiet \"**/*.js\"",
+		"changelog": "node ./scripts/changelog.js",
+		"release:bump-version": "node ./scripts/bump-version.js",
+		"release:publish": "node ./scripts/publish.js"
+	},
+	"bin": {
+		"mrgit": "./index.js"
+	},
+	"files": [
+		"index.js",
+		"lib"
+	],
+	"lint-staged": {
+		"**/*.js": [
+			"eslint --quiet"
+		]
+	},
+	"husky": {
+		"hooks": {
+			"pre-commit": "lint-staged"
+		}
+	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1800,18 +1800,18 @@ escodegen@^1.9.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-ckeditor5@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-ckeditor5/-/eslint-config-ckeditor5-3.1.1.tgz#aeb289e858c7103aac09c9bd9347a60db62eedbc"
-  integrity sha512-fiV+pokuTd8wi9primorw06/XpXfhj7+LopRvuEdzqDumXpP0FUznllrnodogXE4+Mg9qX7tAs6YJeyArqyqQQ==
+eslint-config-ckeditor5@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-ckeditor5/-/eslint-config-ckeditor5-4.0.0.tgz#6a4fc760525a0405532c4d6b095d8a17af3cba58"
+  integrity sha512-PDjWbo/PQ/gEvTGmNnEbLl63H+h0weQQkWV23jVCjvrr2Y5FyrVvQhizF5OqCDb5alSk1+RREUURZGhzMzy8LA==
   dependencies:
-    eslint-plugin-ckeditor5-rules "^1.0.0"
+    eslint-plugin-ckeditor5-rules "^4.0.0"
     eslint-plugin-mocha "^7.0.0"
 
-eslint-plugin-ckeditor5-rules@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-ckeditor5-rules/-/eslint-plugin-ckeditor5-rules-1.3.0.tgz#faf1fde859cf79e989f248e8a08e6955c317fdcd"
-  integrity sha512-7TjodWU2BRxbsCrhagRCn+V2Qh1UGmBnldG/jWL6HJgTPrsDYhqiS86aJUYsLR2FLEW6X39czXfI556qeMkCKQ==
+eslint-plugin-ckeditor5-rules@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ckeditor5-rules/-/eslint-plugin-ckeditor5-rules-4.0.0.tgz#79d1fd8235212fe5b534b404ecba9a0f35aa1f92"
+  integrity sha512-zjePsfFahvkytgyWZtWOwaWyhXMUalTTQwXQ4XbX0x000R/4YmZh64ikCSJuW8v6acfvQcbFtCdXn/8+dipYKg==
 
 eslint-plugin-mocha@^7.0.0:
   version "7.0.1"


### PR DESCRIPTION
Internal: Allowed the "license-header" ESLint rule. See https://github.com/ckeditor/ckeditor5/issues/11468.