### PR TITLE
Node version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "url": "https://github.com/cksource/mrgit.git"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.0.0"
   },
   "author": "CKSource (http://cksource.com/)",
   "license": "MIT",


### PR DESCRIPTION
Other: Updated the required version of Node.js to 18. See ckeditor/ckeditor5#14924.

MAJOR BREAKING CHANGE: Upgraded the minimal versions of Node.js to `18.0.0` due to the end of LTS.