### PR TITLE
Bumped NodeJS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "url": "https://github.com/cksource/mrgit.git"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "author": "CKSource (http://cksource.com/)",
   "license": "MIT",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Upgraded the minimal version of Node.js to 20.0.0 due to the end of LTS.

MAJOR BREAKING CHANGE: Upgraded the minimal version of Node.js to 20.0.0 due to the end of LTS.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
