### PR TITLE
Added fallback for when there is no tag

### DIFF
--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -50,7 +50,7 @@ module.exports = {
 		const latestTagStatusResponse = await execCommand.execute( getExecData( 'git log --tags --simplify-by-decoration --pretty="%S"' ) );
 
 		if ( latestTagStatusResponse.logs.info.length ) {
-			const currentTagStatusResponse = await execCommand.execute( getExecData( 'git describe --abbrev=0 --tags' ) );
+			const currentTagStatusResponse = await execCommand.execute( getExecData( 'git describe --abbrev=0 --tags --always' ) );
 
 			latestTag = latestTagStatusResponse.logs.info[ 0 ].trim().split( '\n' ).shift();
 			currentTag = currentTagStatusResponse.logs.info[ 0 ];

--- a/tests/commands/status.js
+++ b/tests/commands/status.js
@@ -164,7 +164,7 @@ describe( 'commands/status', () => {
 						getCommandArguments( 'git log --tags --simplify-by-decoration --pretty="%S"' )
 					);
 					expect( stubs.execCommand.execute.getCall( 3 ).args[ 0 ] ).to.deep.equal(
-						getCommandArguments( 'git describe --abbrev=0 --tags' )
+						getCommandArguments( 'git describe --abbrev=0 --tags --always' )
 					);
 
 					expect( stubs.gitStatusParser.calledOnce ).to.equal( true );
@@ -259,7 +259,7 @@ describe( 'commands/status', () => {
 						getCommandArguments( 'git log --tags --simplify-by-decoration --pretty="%S"' )
 					);
 					expect( stubs.execCommand.execute.getCall( 3 ).args[ 0 ] ).to.deep.equal(
-						getCommandArguments( 'git describe --abbrev=0 --tags' )
+						getCommandArguments( 'git describe --abbrev=0 --tags --always' )
 					);
 
 					expect( stubs.gitStatusParser.calledOnce ).to.equal( true );
@@ -310,7 +310,7 @@ describe( 'commands/status', () => {
 						getCommandArguments( 'git log --tags --simplify-by-decoration --pretty="%S"' )
 					);
 					expect( stubs.execCommand.execute.getCall( 3 ).args[ 0 ] ).to.deep.equal(
-						getCommandArguments( 'git describe --abbrev=0 --tags' )
+						getCommandArguments( 'git describe --abbrev=0 --tags --always' )
 					);
 
 					expect( stubs.gitStatusParser.calledOnce ).to.equal( true );
@@ -360,7 +360,7 @@ describe( 'commands/status', () => {
 						getCommandArguments( 'git log --tags --simplify-by-decoration --pretty="%S"' )
 					);
 					expect( stubs.execCommand.execute.getCall( 3 ).args[ 0 ] ).to.deep.equal(
-						getCommandArguments( 'git describe --abbrev=0 --tags' )
+						getCommandArguments( 'git describe --abbrev=0 --tags --always' )
 					);
 
 					expect( stubs.gitStatusParser.calledOnce ).to.equal( true );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The `mrgit status` command should not print an error when processing a repository without tags or with a partially cloned history that causes tags to be assigned to non-existing commits. Closes #179.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
