### PR TITLE
Introduced `--config` CLI parameter to provide custom configuration file

### DIFF
--- a/.changelog/20250912141133_i_189.md
+++ b/.changelog/20250912141133_i_189.md
@@ -1,0 +1,45 @@
+---
+# Required: Type of change.
+# Allowed values:
+# - Feature
+# - Fix
+# - Other
+# - Major breaking change
+# - Minor breaking change
+#
+# For guidance on breaking changes, see:
+# https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html#major-and-minor-breaking-changes
+type: Feature
+
+# Optional: Affected package(s), using short names.
+# Can be skipped when processing a non-mono-repository.
+# Example: ckeditor5-core
+scope:
+  -
+
+# Optional: Issues this change closes.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+closes:
+  - 189
+
+# Optional: Related issues.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+see:
+  -
+
+# Optional: Community contributors.
+# Format:
+# - {github-username}
+communityCredits:
+  -
+
+# Before committing, consider removing all comments to reduce file size and enhance readability.
+---
+
+Introduced `--config` CLI parameter which allows providing custom configuration filename that will be used instead of the default `mrgit.json` file.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ mrgit --help
 
 ## Usage
 
-First, create a configuration file `mrgit.json`:
+First, create a configuration file `mrgit.json`. If the project already contains `mrgit.json` file, but you want to provide your own settings, create another `*.json` file and use the `--config <path>` option (described below) to load your custom configuration when executing a command.
 
 ```json
 {
@@ -74,6 +74,9 @@ packages/
 CLI options:
 
 ```
+--config                    Name or path to custom configuration file.
+                            Default: '<cwd>/mrgit.json'
+
 --branch                    For "save" command: whether to save branch names.
                             For "checkout" command: name of branch that would be created.
 
@@ -111,7 +114,7 @@ CLI options:
                             whether the repository will be cloned to packages/@scope/pkgname' or 'packages/pkgname'.
                             Default: 'git'
 
---resolver-default-branch   The branch name to use if not specified in mrgit.json dependencies.
+--resolver-default-branch   The branch name to use if not specified in dependencies in configuration file.
                             Default: master
 
 --scope                     Restricts the command to packages which names match the given glob pattern.
@@ -123,7 +126,7 @@ CLI options:
                             if "$rootRepository" is defined in the config file.
 ```
 
-All these options can also be specified in `mrgit.json` (options passed through CLI takes precedence):
+All these options can also be specified in configuration file (options passed through CLI takes precedence):
 
 ```json
 {
@@ -230,7 +233,7 @@ Example config:
 
 ### Recursive cloning
 
-When the `--recursive` option is used `mrgit` will clone repositories recursively. First, it will clone the `dependencies` specified in `mrgit.json` and, then, their `dependencies` and `devDependencies` specified in `package.json` files located in cloned repositories.
+When the `--recursive` option is used `mrgit` will clone repositories recursively. First, it will clone the `dependencies` specified in configuration file and, then, their `dependencies` and `devDependencies` specified in `package.json` files located in cloned repositories.
 
 However, `mrgit` needs to know repository URLs of those dependencies, as well as which dependencies to clone (usually, only the ones maintained by you). In order to configure that you need to use a custom repository resolver (`--resolver-path`).
 
@@ -275,14 +278,14 @@ If you need to run `mrgit` on a CI server, then configure it to use HTTPS URLs:
 mrgit --resolver-url-template="https://github.com/\${ path }.git"
 ```
 
-You can also use full HTTPS URLs to configure `dependencies` in your `mrgit.json`.
+You can also use full HTTPS URLs to configure `dependencies` in your configuration file.
 
 ### Base branches
 
 When you call `mrgit sync` or `mrgit co`, mrgit will use the following algorithm to determine the branch to which each repository should be checked out:
 
-1. If a branch is defined in `mrgit.json`, use it. A branch can be defined after `#` in a repository URL. For example: `"@cksource/foo": "cksource/foo#dev"`.
-2. If a tag is defined in `mrgit.json`, use it. A tag can be defined after `@` in a repository URL. Its either a specific tag name, such as `@v30.0.0`, or `@latest` tag that will look for the latest available tag.
+1. If a branch is defined in configuration file, use it. A branch can be defined after `#` in a repository URL. For example: `"@cksource/foo": "cksource/foo#dev"`.
+2. If a tag is defined in configuration file, use it. A tag can be defined after `@` in a repository URL. Its either a specific tag name, such as `@v30.0.0`, or `@latest` tag that will look for the latest available tag.
 3. If the root repository (assuming, it is a repository) is on one of the "base branches", use that branch name.
 4. Otherwise, use `master` branch.
 
@@ -312,13 +315,13 @@ $ mrgit [command] --help
 
 ### sync
 
-Updates dependencies. Switches repositories to correct branches or tags (specified in `mrgit.json`) and pulls changes.
+Updates dependencies. Switches repositories to correct branches or tags (specified in configuration file) and pulls changes.
 
 If any dependency is missing, the command will install this dependency as well.
 
 This command does not touch repositories in which there are uncommitted changes.
 
-If in the packages directory will be located some directories that are not specified in `mrgit.json`, paths to these directories
+If in the packages directory will be located some directories that are not specified in configuration file, paths to these directories
 will be printed out on the screen.
 
 Examples:
@@ -409,7 +412,7 @@ mrgit merge develop --message 'These changes are required for the future release
 
 ### save
 
-Saves hashes of packages in `mrgit.json`. It allows to easily fix project to a specific state.
+Saves hashes of packages in configuration file. It allows to easily fix project to a specific state.
 
 Example:
 
@@ -487,7 +490,7 @@ mrgit checkout
 mrgit co
 ```
 
-If specified an argument, specified branch will be used instead of default or saved in `mrgit.json` file.
+If specified an argument, specified branch will be used instead of default or saved in configuration file.
 
 ```bash
 # Checkout all repositories to "stable" branch.

--- a/index.js
+++ b/index.js
@@ -65,12 +65,16 @@ function handleCli() {
         ${ c( 'fetch' ) }                       Fetches existing repositories.
         ${ c( 'pull' ) }                        Pulls changes in existing repositories.
         ${ c( 'push' ) }                        Pushes changes in existing repositories to remotes.
-        ${ c( 'save' ) }                        Saves hashes of packages in mrgit.json. It allows to easily fix project to a specific state.
+        ${ c( 'save' ) }                        Saves hashes of packages in a configuration file.
+                                    Useful for restoring the project to a specific state.
         ${ c( 'status' ) }                      Prints a table which contains useful information about the status of repositories.
         ${ c( 'sync' ) }                        Updates packages to the latest versions or install missing ones.
 
 
     ${ u( 'Options:' ) }
+        ${ y( '--config' ) }                    Name or path to custom configuration file.
+                                    ${ g( 'Default: \'<cwd>/mrgit.json\'' ) }
+
         ${ y( '--branch' ) }                    For "${ u( 'save' ) }" command: whether to save branch names.
                                     For "${ u( 'checkout' ) }" command: name of branch that would be created.
 
@@ -108,7 +112,7 @@ function handleCli() {
                                     whether the repository will be cloned to packages/@scope/pkgname' or 'packages/pkgname'.
                                     ${ g( 'Default: \'git\'' ) }
 
-        ${ y( '--resolver-default-branch' ) }   The branch name to use if not specified in mrgit.json dependencies.
+        ${ y( '--resolver-default-branch' ) }   The branch name to use if not specified in dependencies in configuration file.
                                     ${ g( 'Default: master' ) }
 
         ${ y( '--scope' ) }                     Restricts the command to packages which names match the given glob pattern.

--- a/lib/commands/checkout.js
+++ b/lib/commands/checkout.js
@@ -21,18 +21,18 @@ module.exports = {
 
 		return `
     ${ u( 'Description:' ) }
-        Checks out the repository to specified branch or commit saved in "mrgit.json" file.
-        
-        If specified a branch as an argument for "checkout" command, mrgit will use the branch 
-        instead of data saved in "mrgit.json". E.g "${ g( 'mrgit checkout master' ) }" will check out
+        Checks out the repository to specified branch or commit saved in configuration file.
+
+        If specified a branch as an argument for "checkout" command, mrgit will use the branch
+        instead of data saved in configuration file. E.g "${ g( 'mrgit checkout master' ) }" will check out
         all branches to "master".
 
         You can also call "${ g( 'mrgit checkout .' ) }" in order to restore files before changes.
-        
+
     ${ u( 'Options:' ) }
         ${ y( '--branch' ) } (-b)             If specified, mrgit will create given branch in all repositories
                                   that contain changes that could be committed.
-                                  ${ g( '> mrgit checkout --branch develop' ) }    
+                                  ${ g( '> mrgit checkout --branch develop' ) }
 		`;
 	},
 

--- a/lib/commands/save.js
+++ b/lib/commands/save.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-const path = require( 'upath' );
 const chalk = require( 'chalk' );
 const updateJsonFile = require( '../utils/updatejsonfile' );
 const gitStatusParser = require( '../utils/gitstatusparser' );
@@ -22,7 +21,7 @@ module.exports = {
 
 		return `
     ${ u( 'Description:' ) }
-        Saves hashes of commits or branches which repositories are checked out in "mrgit.json" file.
+        Saves hashes of commits or branches which repositories are checked out in configuration file.
 
     ${ u( 'Options:' ) }
         ${ y( '--hash' ) }                    Whether to save hashes (id of last commit) on current branch.
@@ -104,12 +103,9 @@ module.exports = {
 	 * @param {Options} toolOptions Options resolved by mrgit.
 	 */
 	afterExecute( processedPackages, commandResponses, toolOptions ) {
-		const cwd = require( '../utils/getcwd' )();
-		const mrgitJsonPath = path.join( cwd, 'mrgit.json' );
-
 		const tagPattern = /@([^ ~^:?*\\]*?)$/;
 
-		updateJsonFile( mrgitJsonPath, json => {
+		updateJsonFile( toolOptions.config, json => {
 			for ( const response of commandResponses.values() ) {
 				const repository = json.dependencies[ response.packageName ]
 					.replace( tagPattern, '' )

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -23,7 +23,7 @@ module.exports = {
         Prints a useful table that contains status of every repository. It displays:
 
             * current branch,
-            * whether current branch is equal to specified in "mrgit.json" file,
+            * whether current branch is equal to specified in configuration file,
             * whether current branch is behind or ahead with the remote,
             * current commit short hash,
             * how many files is staged, modified and untracked.
@@ -188,7 +188,7 @@ module.exports = {
 				`${ chalk.red( 'M' ) } modified files`,
 				`${ chalk.blue( '?' ) } untracked files`,
 				`\n${ chalk.green( 'L' ) } latest tag`,
-				`${ chalk.cyan( '!' ) } not on a branch or a tag specified in "mrgit.json"`
+				`${ chalk.cyan( '!' ) } not on a branch or a tag specified in configuration file`
 			];
 
 			console.log( `${ chalk.bold( 'Legend:' ) }\n${ legend.join( ', ' ) }.` );

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -30,7 +30,7 @@ module.exports = {
             * Checks whether repository can be updated. If the repository contains uncommitted changes,
               the process is aborted.
             * Fetches changes from the remote.
-            * Checks out on the branch or particular commit that is specified in "mrgit.json" file.
+            * Checks out on the branch or particular commit that is specified in configuration file.
             * Pulls the changes if the repository is not detached at some commit.
 
     ${ u( 'Options:' ) }
@@ -188,7 +188,7 @@ module.exports = {
 
 		if ( skippedPackages.length ) {
 			console.log(
-				chalk.yellow( 'Paths to directories listed below are skipped by mrgit because they are not defined in "mrgit.json":' )
+				chalk.yellow( 'Paths to directories listed below are skipped by mrgit because they are not defined in configuration file:' )
 			);
 
 			skippedPackages.forEach( absolutePath => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,6 @@ const displayLog = require( './utils/displaylog' );
 const getOptions = require( './utils/getoptions' );
 const getPackageNames = require( './utils/getpackagenames' );
 const getCommandInstance = require( './utils/getcommandinstance' );
-const getCwd = require( './utils/getcwd' );
 const { addRootRepositorySuffix } = require( './utils/rootrepositoryutils' );
 
 const CHILD_PROCESS_PATH = require.resolve( './utils/child-process' );
@@ -29,9 +28,8 @@ module.exports = function( args, options ) {
 		return;
 	}
 
-	const cwd = getCwd();
 	const startTime = process.hrtime();
-	const toolOptions = getOptions( options, cwd );
+	const toolOptions = getOptions( options );
 	const repositoryResolver = require( toolOptions.resolverPath );
 	const forkPool = createForkPool( CHILD_PROCESS_PATH );
 
@@ -44,7 +42,7 @@ module.exports = function( args, options ) {
 		process.exit( 1 );
 	}
 
-	const mainPkgJsonPath = path.resolve( cwd, 'package.json' );
+	const mainPkgJsonPath = path.resolve( toolOptions.cwd, 'package.json' );
 	const mainPackageName = fs.existsSync( mainPkgJsonPath ) ? require( mainPkgJsonPath ).name : '';
 
 	if ( command.beforeExecute ) {
@@ -178,7 +176,7 @@ module.exports = function( args, options ) {
 			return false;
 		}
 
-		if ( fs.existsSync( path.join( cwd, '.git' ) ) ) {
+		if ( fs.existsSync( path.join( toolOptions.cwd, '.git' ) ) ) {
 			return false;
 		}
 

--- a/lib/utils/getcwd.js
+++ b/lib/utils/getcwd.js
@@ -11,19 +11,19 @@ const path = require( 'upath' );
 /**
  * Returns an absolute path to the directory that contains a configuration file.
  *
- * It scans directory tree up for `mrgit.json` file. If the file won't be found,
+ * It scans directory tree up for a configuration file. If the file won't be found,
  * an exception should be thrown.
  *
+ * @param {String} config Configuration file.
+ * @param {String} [cwd=process.cwd()] An absolute path to the directory where searching for the configuration file is started.
  * @returns {String}
  */
-module.exports = function cwdResolver() {
-	let cwd = process.cwd();
-
-	while ( !fs.existsSync( path.join( cwd, 'mrgit.json' ) ) ) {
+module.exports = function cwdResolver( config, cwd = process.cwd() ) {
+	while ( !fs.existsSync( path.resolve( cwd, config ) ) ) {
 		const parentCwd = path.resolve( cwd, '..' );
 
 		if ( cwd === parentCwd ) {
-			throw new Error( 'Cannot find the "mrgit.json" file.' );
+			throw new Error( 'Cannot find the configuration file.' );
 		}
 
 		cwd = parentCwd;

--- a/lib/utils/getoptions.js
+++ b/lib/utils/getoptions.js
@@ -8,18 +8,19 @@
 const fs = require( 'fs' );
 const path = require( 'upath' );
 const shell = require( 'shelljs' );
+const getCwd = require( './getcwd' );
 
 /**
  * @param {Object} callOptions Call options.
- * @param {String} cwd An absolute path to the directory where `mrgit.json` is available.
+ * @param {String} [cwd=process.cwd()] An absolute path to the directory where searching for the configuration file is started.
  * @returns {Options} The options object.
  */
-module.exports = function getOptions( callOptions, cwd ) {
-	const mrgitJsonPath = path.resolve( cwd, 'mrgit.json' );
+module.exports = function getOptions( callOptions, cwd = process.cwd() ) {
+	const configName = callOptions.config || 'mrgit.json';
+	const configPath = path.resolve( getCwd( configName, cwd ), configName );
+	const configOptions = require( configPath );
 
-	// Default options.
-	let options = {
-		cwd,
+	const defaultOptions = {
 		packages: 'packages',
 		resolverPath: path.resolve( __dirname, '..', 'default-resolver.js' ),
 		resolverUrlTemplate: 'git@github.com:${ path }.git',
@@ -33,13 +34,15 @@ module.exports = function getOptions( callOptions, cwd ) {
 		baseBranches: []
 	};
 
-	if ( fs.existsSync( mrgitJsonPath ) ) {
-		options = Object.assign( options, require( mrgitJsonPath ), options );
-	}
+	const options = {
+		...defaultOptions,
+		...configOptions,
+		...callOptions
+	};
 
-	options = Object.assign( options, callOptions );
-
-	options.packages = path.resolve( cwd, options.packages );
+	options.config = configPath;
+	options.cwd = path.dirname( configPath );
+	options.packages = path.resolve( options.cwd, options.packages );
 
 	if ( !Array.isArray( options.packagesPrefix ) ) {
 		options.packagesPrefix = [ options.packagesPrefix ];
@@ -47,7 +50,7 @@ module.exports = function getOptions( callOptions, cwd ) {
 
 	// Check if under specified `cwd` path, the git repository exists.
 	// If so, find a branch name that the repository is checked out. See #103.
-	if ( fs.existsSync( path.join( cwd, '.git' ) ) ) {
+	if ( fs.existsSync( path.join( options.cwd, '.git' ) ) ) {
 		const response = shell.exec( 'git rev-parse --abbrev-ref HEAD', { silent: true } );
 
 		options.cwdPackageBranch = response.stdout.trim();
@@ -58,7 +61,7 @@ module.exports = function getOptions( callOptions, cwd ) {
 	}
 
 	if ( !options.presets || !options.presets[ options.preset ] ) {
-		throw new Error( `Preset "${ options.preset }" is not defined in "mrgit.json" file.` );
+		throw new Error( `Preset "${ options.preset }" is not defined in configuration file.` );
 	}
 
 	if ( options.presets[ options.preset ].$rootRepository ) {
@@ -68,7 +71,7 @@ module.exports = function getOptions( callOptions, cwd ) {
 	}
 
 	if ( options.dependencies ) {
-		options.dependencies = Object.assign( options.dependencies, options.presets[ options.preset ] );
+		Object.assign( options.dependencies, options.presets[ options.preset ] );
 	}
 
 	return options;
@@ -77,7 +80,9 @@ module.exports = function getOptions( callOptions, cwd ) {
 /**
  * @typedef {Object} Options
  *
- * @property {String} cwd An absolute path to the directory which contains `mrgit.json` file.
+ * @property {String} cwd An absolute path to the directory which contains configuration file.
+ *
+ * @property {String} [config='<cwd>/mrgit.json'] An absolute path to configuration file.
  *
  * @property {String} [packages='<cwd>/packages/'] Directory to which all repositories will be cloned.
  *
@@ -96,7 +101,7 @@ module.exports = function getOptions( callOptions, cwd ) {
  * This option can be useful when scoped npm packages are used and one wants to decide
  * whether the repository will be cloned to packages/@scope/pkgname' or 'packages/pkgname'.
  *
- * @property {String} [resolverDefaultBranch='master'] The branch name to use if not specified in mrgit.json dependencies.
+ * @property {String} [resolverDefaultBranch='master'] The branch name to use if not specified in dependencies in configuration file.
  *
  * @property {String|null} [ignore=null] Ignores packages with names matching the given glob.
  *

--- a/lib/utils/parserepositoryurl.js
+++ b/lib/utils/parserepositoryurl.js
@@ -12,10 +12,10 @@ const url = require( 'url' );
 const tagPattern = /@([^ ~^:?*\\]*?)$/;
 
 /**
- * Parses repository URL taken from `mrgit.json`'s dependencies and returns
+ * Parses repository URL taken from dependencies provided in configuration file and returns
  * it as an object containing repository URL and branch name.
  *
- * @param {String} repositoryUrl The repository URL in formats supported by `mrgit.json`.
+ * @param {String} repositoryUrl The repository URL in formats supported by configuration file.
  * @param {Object} options
  * @param {String} [options.urlTemplate] The URL template.
  * Used if `repositoryUrl` defines only `'<organization>/<repositoryName>'`.
@@ -66,7 +66,7 @@ module.exports = function parseRepositoryUrl( repositoryUrl, options = {} ) {
 function getBranch( parsedUrl, options ) {
 	const defaultBranch = options.defaultBranch || 'master';
 
-	// Check if branch is defined in mrgit.json. Use it.
+	// Check if branch is defined in configuration file. Use it.
 	if ( parsedUrl.hash ) {
 		return parsedUrl.hash.slice( 1 );
 	}

--- a/tests/commands/save.js
+++ b/tests/commands/save.js
@@ -33,7 +33,9 @@ describe( 'commands/save', () => {
 			gitStatusParser: sinon.stub()
 		};
 
-		toolOptions = {};
+		toolOptions = {
+			config: normalizedDirname + '/mrgit.json'
+		};
 
 		commandData = {
 			packageName: 'test-package',
@@ -125,7 +127,8 @@ describe( 'commands/save', () => {
 						packageName: commandData.packageName,
 						arguments: [ 'git rev-parse HEAD' ],
 						toolOptions: {
-							hash: true
+							hash: true,
+							config: normalizedDirname + '/mrgit.json'
 						}
 					} );
 
@@ -159,7 +162,8 @@ describe( 'commands/save', () => {
 						packageName: commandData.packageName,
 						arguments: [ 'git status --branch --porcelain' ],
 						toolOptions: {
-							branch: true
+							branch: true,
+							config: normalizedDirname + '/mrgit.json'
 						}
 					} );
 

--- a/tests/commands/sync.js
+++ b/tests/commands/sync.js
@@ -688,7 +688,7 @@ describe( 'commands/sync', () => {
 			expect( consoleLog.callCount ).to.equal( 3 );
 			expect( consoleLog.firstCall.args[ 0 ] ).to.match( /2 packages have been processed\./ );
 			expect( consoleLog.secondCall.args[ 0 ] ).to.match(
-				/Paths to directories listed below are skipped by mrgit because they are not defined in "mrgit\.json":/
+				/Paths to directories listed below are skipped by mrgit because they are not defined in configuration file:/
 			);
 			expect( consoleLog.thirdCall.args[ 0 ] ).to.match( / {2}- .*\/packages\/package-3/ );
 		} );
@@ -746,7 +746,7 @@ describe( 'commands/sync', () => {
 			expect( consoleLog.callCount ).to.equal( 3 );
 			expect( consoleLog.firstCall.args[ 0 ] ).to.match( /2 packages have been processed\./ );
 			expect( consoleLog.secondCall.args[ 0 ] ).to.match(
-				/Paths to directories listed below are skipped by mrgit because they are not defined in "mrgit\.json":/
+				/Paths to directories listed below are skipped by mrgit because they are not defined in configuration file:/
 			);
 			expect( consoleLog.thirdCall.args[ 0 ] ).to.match( / {2}- .*\/packages\/@foo\/package-3/ );
 		} );

--- a/tests/fixtures/project-with-custom-config/mrgit-custom.json
+++ b/tests/fixtures/project-with-custom-config/mrgit-custom.json
@@ -1,0 +1,6 @@
+{
+  "packages": "foo",
+  "dependencies": {
+    "simple-package": "a/b"
+  }
+}

--- a/tests/utils/getcwd.js
+++ b/tests/utils/getcwd.js
@@ -22,10 +22,16 @@ describe( 'utils', () => {
 			sinon.stub( process, 'cwd' ).returns( '/workspace/ckeditor/ckeditor5' );
 			sinon.stub( fs, 'existsSync' ).returns( true );
 
-			expect( getCwd() ).to.equal( '/workspace/ckeditor/ckeditor5' );
+			expect( getCwd( 'mrgit.json' ) ).to.equal( '/workspace/ckeditor/ckeditor5' );
 		} );
 
-		it( 'scans dir tree up in order to find "mrgit.json" file', () => {
+		it( 'returns a path to the "mrgit.json" when custom working directory is provided', () => {
+			sinon.stub( fs, 'existsSync' ).returns( true );
+
+			expect( getCwd( 'mrgit.json', '/another-workspace/ckeditor/ckeditor5' ) ).to.equal( '/another-workspace/ckeditor/ckeditor5' );
+		} );
+
+		it( 'scans dir tree up in order to find configuration file', () => {
 			sinon.stub( process, 'cwd' ).returns( '/workspace/ckeditor/ckeditor5/packages/ckeditor5-engine/node_modules/@ckeditor' );
 
 			const existsSync = sinon.stub( fs, 'existsSync' );
@@ -41,24 +47,26 @@ describe( 'utils', () => {
 			// /workspace/ckeditor/ckeditor5
 			existsSync.onCall( 4 ).returns( true );
 
-			expect( getCwd() ).to.equal( '/workspace/ckeditor/ckeditor5' );
+			expect( getCwd( 'mrgit-custom.json' ) ).to.equal( '/workspace/ckeditor/ckeditor5' );
 
 			expect( existsSync.getCall( 0 ).args[ 0 ] ).to.equal(
-				'/workspace/ckeditor/ckeditor5/packages/ckeditor5-engine/node_modules/@ckeditor/mrgit.json'
+				'/workspace/ckeditor/ckeditor5/packages/ckeditor5-engine/node_modules/@ckeditor/mrgit-custom.json'
 			);
 			expect( existsSync.getCall( 1 ).args[ 0 ] ).to.equal(
-				'/workspace/ckeditor/ckeditor5/packages/ckeditor5-engine/node_modules/mrgit.json'
+				'/workspace/ckeditor/ckeditor5/packages/ckeditor5-engine/node_modules/mrgit-custom.json'
 			);
-			expect( existsSync.getCall( 2 ).args[ 0 ] ).to.equal( '/workspace/ckeditor/ckeditor5/packages/ckeditor5-engine/mrgit.json' );
-			expect( existsSync.getCall( 3 ).args[ 0 ] ).to.equal( '/workspace/ckeditor/ckeditor5/packages/mrgit.json' );
-			expect( existsSync.getCall( 4 ).args[ 0 ] ).to.equal( '/workspace/ckeditor/ckeditor5/mrgit.json' );
+			expect( existsSync.getCall( 2 ).args[ 0 ] ).to.equal(
+				'/workspace/ckeditor/ckeditor5/packages/ckeditor5-engine/mrgit-custom.json'
+			);
+			expect( existsSync.getCall( 3 ).args[ 0 ] ).to.equal( '/workspace/ckeditor/ckeditor5/packages/mrgit-custom.json' );
+			expect( existsSync.getCall( 4 ).args[ 0 ] ).to.equal( '/workspace/ckeditor/ckeditor5/mrgit-custom.json' );
 		} );
 
-		it( 'throws an error if the "mrgit.json" cannot be found', () => {
+		it( 'throws an error if the configuration file cannot be found', () => {
 			sinon.stub( process, 'cwd' ).returns( '/workspace/ckeditor' );
 			sinon.stub( fs, 'existsSync' ).returns( false );
 
-			expect( () => getCwd() ).to.throw( Error, 'Cannot find the "mrgit.json" file.' );
+			expect( () => getCwd( 'mrgit.json' ) ).to.throw( Error, 'Cannot find the configuration file.' );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn run nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Introduced `--config` CLI parameter which allows providing custom configuration filename that will be used instead of the default `mrgit.json` file.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #189

---

### 💡 Additional information

My test cases:
1. Create custom `mrgit-custom.json` configuration file in this repository. Below you can find my example configuration:

    ```json
    {
      "packages": "external/",
      "$rootRepository": "cksource/mrgit",
      "dependencies": {
        "ckeditor5-dev": "ckeditor/ckeditor5-dev",
        "ckeditor5-linters-config": "ckeditor/ckeditor5-linters-config"
      },
      "presets": {
        "dev": {
          "$rootRepository": "cksource/mrgit",
          "ckeditor5-dev": "ckeditor/ckeditor5-dev",
          "ckeditor5-linters-config": "ckeditor/ckeditor5-linters-config"
        }
      }
    }
    ```

2. Execute `mrgit` commands:
   - `node index.js` - new `--config` CLI parameter is defined.
   - `node index.js sync` - throws "Cannot find the configuration file." error. 
   - `node index.js sync --config mrgit-custom.json` - clones repositories into `./external` directory.
   - `node index.js save --config mrgit-custom.json --preset dev` - stores hashes in `mrgit-custom.json` file in the `dev` preset.