### PR TITLE
Upgrade to and require at least Node v24.11.

### DIFF
--- a/.changelog/20251030140700_internal_4151_upgrade_to_node_24_11.md
+++ b/.changelog/20251030140700_internal_4151_upgrade_to_node_24_11.md
@@ -1,0 +1,5 @@
+---
+type: Breaking change
+---
+
+Upgrade to and require at least Node v24.11.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ commands:
 jobs:
   notify_ci_failure:
     docker:
-      - image: cimg/node:22.12.0
+      - image: cimg/node:24.11.0
     parameters:
       hideAuthor:
         type: string
@@ -97,7 +97,7 @@ jobs:
 
   validate_and_tests:
     docker:
-      - image: cimg/node:22.12.0
+      - image: cimg/node:24.11.0
     steps:
       - checkout
       - bootstrap_repository_command
@@ -128,7 +128,7 @@ jobs:
 
   release_prepare:
     docker:
-      - image: cimg/node:22.12.0
+      - image: cimg/node:24.11.0
     steps:
       - checkout
       - bootstrap_repository_command
@@ -138,7 +138,7 @@ jobs:
 
   trigger_release_process:
     docker:
-      - image: cimg/node:22.12.0
+      - image: cimg/node:24.11.0
     steps:
       - checkout
       - bootstrap_repository_command
@@ -167,7 +167,7 @@ jobs:
 
   release_project:
     docker:
-      - image: cimg/node:22.12.0
+      - image: cimg/node:24.11.0
     steps:
       - checkout
       - bootstrap_repository_command

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "url": "https://github.com/cksource/mrgit.git"
   },
   "engines": {
-    "node": ">=22.0.0",
+    "node": ">=24.11.0",
     "pnpm": ">=10.14.0",
     "yarn": "\n\n┌─────────────────────────┐\n│  Hey, we use pnpm now!  │\n└─────────────────────────┘\n\n"
   },


### PR DESCRIPTION
### 🚀 Summary

Upgrade to and require at least Node v24.11.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5-internal/issues/4151

---

### 💡 Additional information

N/A
