### PR TITLE
Harden internal Git command execution against shell injection

### DIFF
--- a/.changelog/20260223070951_fix_harden_git_command_execution.md
+++ b/.changelog/20260223070951_fix_harden_git_command_execution.md
@@ -1,5 +1,7 @@
 ---
 type: Fix
+closes:
+  - https://github.com/cksource/mrgit/issues/216
 ---
 
 Harden internal Git command execution by running `diff`, `push`, `checkout`, `close`, `commit`, and `sync` commands without shell interpolation, so command arguments are treated as literal values.

--- a/.changelog/20260223070951_fix_harden_git_command_execution.md
+++ b/.changelog/20260223070951_fix_harden_git_command_execution.md
@@ -1,0 +1,5 @@
+---
+type: Fix
+---
+
+Harden internal Git command execution by running `diff`, `push`, `checkout`, `close`, `commit`, and `sync` commands without shell interpolation, so command arguments are treated as literal values.

--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ mrgit fetch
 
 Executes specified shell command in existing repositories.
 
+`mrgit exec` is intentionally a raw shell entry point. Run only trusted commands and do not pass untrusted input.
+
 Example:
 
 ```bash

--- a/lib/commands/checkout.js
+++ b/lib/commands/checkout.js
@@ -46,9 +46,8 @@ export default {
 		}
 
 		const branch = data.arguments[ 0 ] || data.repository.branch;
-		const checkoutCommand = `git checkout ${ branch }`;
 
-		return execCommand.execute( this._getExecData( checkoutCommand, data ) );
+		return execCommand.executeGit( data, [ 'checkout', branch ] );
 	},
 
 	/**
@@ -62,7 +61,7 @@ export default {
 	_createAndCheckout( branch, data ) {
 		const log = logFactory();
 
-		return execCommand.execute( this._getExecData( 'git status --branch --porcelain', data ) )
+		return execCommand.executeGit( data, [ 'status', '--branch', '--porcelain' ] )
 			.then( execResponse => {
 				const status = gitStatusParser( execResponse.logs.info[ 0 ] );
 
@@ -74,23 +73,7 @@ export default {
 					};
 				}
 
-				const checkoutCommand = `git checkout -b ${ branch }`;
-
-				return execCommand.execute( this._getExecData( checkoutCommand, data ) );
+				return execCommand.executeGit( data, [ 'checkout', '-b', branch ] );
 			} );
-	},
-
-	/**
-	 * Prepares new configuration object for "execute" command which is called inside this command.
-	 *
-	 * @private
-	 * @param {String} command
-	 * @param {CommandData} data
-	 * @returns {CommandData}
-	 */
-	_getExecData( command, data ) {
-		return Object.assign( {}, data, {
-			arguments: [ command ]
-		} );
 	}
 };

--- a/lib/commands/close.js
+++ b/lib/commands/close.js
@@ -51,7 +51,7 @@ export default {
 		const log = logFactory();
 		const branch = data.arguments[ 0 ];
 
-		return execCommand.execute( getExecData( `git branch --list ${ branch }` ) )
+		return execCommand.executeGit( data, [ 'branch', '--list', branch ] )
 			.then( async execResponse => {
 				const branchExists = Boolean( execResponse.logs.info[ 0 ] );
 
@@ -63,7 +63,7 @@ export default {
 					};
 				}
 
-				const commandResponse = await execCommand.execute( getExecData( 'git branch --show-current' ) );
+				const commandResponse = await execCommand.executeGit( data, [ 'branch', '--show-current' ] );
 				const detachedHead = !commandResponse.logs.info[ 0 ];
 
 				if ( detachedHead ) {
@@ -76,25 +76,30 @@ export default {
 
 				const mergeMessage = this._getMergeMessage( data.toolOptions, data.arguments );
 				const commitTitle = `Merge branch '${ branch }'`;
-
-				let mergeCommand = `git merge ${ branch } --no-ff -m "${ commitTitle }"`;
+				const mergeCommand = [
+					'merge',
+					branch,
+					'--no-ff',
+					'-m',
+					commitTitle
+				];
 
 				if ( mergeMessage.length ) {
-					mergeCommand += ' ' + mergeMessage.map( message => `-m "${ message }"` ).join( ' ' );
+					mergeCommand.push( ...mergeMessage.flatMap( message => [ '-m', message ] ) );
 				}
 
-				return execCommand.execute( getExecData( mergeCommand ) )
+				return execCommand.executeGit( data, mergeCommand )
 					.then( execResponse => {
 						log.concat( execResponse.logs );
 						log.info( `Removing "${ branch }" branch from the local registry.` );
 
-						return execCommand.execute( getExecData( `git branch -d ${ branch }` ) );
+						return execCommand.executeGit( data, [ 'branch', '-d', branch ] );
 					} )
 					.then( execResponse => {
 						log.concat( execResponse.logs );
 						log.info( `Removing "${ branch }" branch from the remote.` );
 
-						return execCommand.execute( getExecData( `git push origin :${ branch }` ) );
+						return execCommand.executeGit( data, [ 'push', 'origin', `:${ branch }` ] );
 					} )
 					.then( execResponse => {
 						log.concat( execResponse.logs );
@@ -102,12 +107,6 @@ export default {
 						return { logs: log.all() };
 					} );
 			} );
-
-		function getExecData( command ) {
-			return Object.assign( {}, data, {
-				arguments: [ command ]
-			} );
-		}
 	},
 
 	/**

--- a/lib/commands/commit.js
+++ b/lib/commands/commit.js
@@ -57,7 +57,7 @@ export default {
 	execute( data ) {
 		const log = logFactory();
 
-		return execCommand.execute( getExecData( 'git status --branch --porcelain' ) )
+		return execCommand.executeGit( data, [ 'status', '--branch', '--porcelain' ] )
 			.then( execResponse => {
 				const status = gitStatusParser( execResponse.logs.info[ 0 ] );
 
@@ -78,32 +78,26 @@ export default {
 				}
 
 				const cliOptions = this._parseArguments( data.arguments );
-				const commitCommand = this._buildCliCommand( data.toolOptions, cliOptions );
+				const commitCommand = this._buildCliArguments( data.toolOptions, cliOptions );
 
-				return execCommand.execute( getExecData( commitCommand ) );
+				return execCommand.executeGit( data, commitCommand );
 			} );
-
-		function getExecData( command ) {
-			return Object.assign( {}, data, {
-				arguments: [ command ]
-			} );
-		}
 	},
 
 	/**
 	 * @private
 	 * @param {options} toolOptions Options resolved by mrgit.
 	 * @param {Object} cliOptions Parsed arguments provided by the user via CLI.
-	 * @returns {String}
+	 * @returns {Array.<String>}
 	 */
-	_buildCliCommand( toolOptions, cliOptions ) {
+	_buildCliArguments( toolOptions, cliOptions ) {
 		const commitMessage = this._getCommitMessage( toolOptions, cliOptions );
-		let command = 'git commit -a';
+		const command = [ 'commit', '-a' ];
 
-		command += ' ' + commitMessage.map( message => `-m "${ message }"` ).join( ' ' );
+		command.push( ...commitMessage.flatMap( message => [ '-m', message ] ) );
 
 		if ( cliOptions[ 'no-verify' ] ) {
-			command += ' -n';
+			command.push( '-n' );
 		}
 
 		return command;

--- a/lib/commands/diff.js
+++ b/lib/commands/diff.js
@@ -41,9 +41,9 @@ export default {
 	 * @returns {Promise}
 	 */
 	execute( data ) {
-		const diffCommand = ( 'git diff --color ' + data.arguments.join( ' ' ) ).trim();
+		const commandArguments = [ 'diff', '--color', ...data.arguments ];
 
-		return execCommand.execute( getExecData( diffCommand ) )
+		return execCommand.executeGit( data, commandArguments )
 			.then( execResponse => {
 				if ( !execResponse.logs.info.length ) {
 					return {};
@@ -51,12 +51,6 @@ export default {
 
 				return execResponse;
 			} );
-
-		function getExecData( command ) {
-			return Object.assign( {}, data, {
-				arguments: [ command ]
-			} );
-		}
 	},
 
 	afterExecute() {

--- a/lib/commands/exec.js
+++ b/lib/commands/exec.js
@@ -8,6 +8,7 @@ import upath from 'upath';
 import chalk from 'chalk';
 import { shell } from '../utils/shell.js';
 import { logFactory } from '../utils/log.js';
+import { runGitCommand } from '../utils/rungitcommand.js';
 
 export default {
 	name: 'exec',
@@ -73,5 +74,48 @@ export default {
 					reject( { logs: log.all() } );
 				} );
 		} );
+	},
+
+	/**
+	 * Executes a git command in a repository with shell interpolation disabled.
+	 *
+	 * @param {CommandData} data
+	 * @param {Array.<String>} commandArguments
+	 * @returns {Promise}
+	 */
+	executeGit( data, commandArguments ) {
+		const log = logFactory();
+		const repositoryPath = this._getRepositoryPath( data );
+
+		if ( !fs.existsSync( repositoryPath ) ) {
+			log.error( `Package "${ data.packageName }" is not available. Run "mrgit sync" in order to download the package.` );
+
+			return Promise.reject( { logs: log.all() } );
+		}
+
+		return runGitCommand( commandArguments, { cwd: repositoryPath } )
+			.then( output => {
+				log.info( output );
+
+				return { logs: log.all() };
+			} )
+			.catch( error => {
+				log.error( error.message || error );
+
+				return Promise.reject( { logs: log.all() } );
+			} );
+	},
+
+	/**
+	 * @private
+	 * @param {CommandData} data
+	 * @returns {String}
+	 */
+	_getRepositoryPath( data ) {
+		if ( data.isRootRepository ) {
+			return data.toolOptions.cwd;
+		}
+
+		return upath.join( data.toolOptions.packages, data.repository.directory );
 	}
 };

--- a/lib/commands/push.js
+++ b/lib/commands/push.js
@@ -47,7 +47,7 @@ export default {
 			}
 		}
 
-		const commandResponse = await execCommand.execute( getExecData( 'git branch --show-current' ) );
+		const commandResponse = await execCommand.executeGit( data, [ 'branch', '--show-current' ] );
 		const currentlyOnBranch = Boolean( commandResponse.logs.info[ 0 ] );
 
 		if ( !currentlyOnBranch ) {
@@ -59,15 +59,7 @@ export default {
 			} );
 		}
 
-		const pushCommand = ( 'git push ' + data.arguments.join( ' ' ) ).trim();
-
-		return execCommand.execute( getExecData( pushCommand ) );
-
-		function getExecData( command ) {
-			return Object.assign( {}, data, {
-				arguments: [ command ]
-			} );
-		}
+		return execCommand.executeGit( data, [ 'push', ...data.arguments ] );
 	},
 
 	/**

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -8,8 +8,8 @@ import upath from 'upath';
 import chalk from 'chalk';
 import execCommand from './exec.js';
 import { pathToFileURL } from 'node:url';
-import { shell } from '../utils/shell.js';
 import { logFactory } from '../utils/log.js';
+import { runGitCommand } from '../utils/rungitcommand.js';
 
 export default {
 	name: 'sync',
@@ -65,7 +65,7 @@ export default {
 			}
 		}
 
-		return execCommand.execute( getExecData( 'git status -s' ) )
+		return execCommand.executeGit( data, [ 'status', '-s' ] )
 			.then( async response => {
 				const stdout = response.logs.info.join( '\n' ).trim();
 
@@ -73,7 +73,7 @@ export default {
 					throw new Error( `Package "${ data.packageName }" has uncommitted changes. Aborted.` );
 				}
 
-				return execCommand.execute( getExecData( 'git fetch' ) );
+				return execCommand.executeGit( data, [ 'fetch' ] );
 			} )
 			.then( response => {
 				log.concat( response.logs );
@@ -84,9 +84,12 @@ export default {
 				if ( !data.repository.tag ) {
 					checkoutValue = data.repository.branch;
 				} else if ( data.repository.tag === 'latest' ) {
-					const commandOutput = await execCommand.execute(
-						getExecData( 'git log --tags --simplify-by-decoration --pretty="%S"' )
-					);
+					const commandOutput = await execCommand.executeGit( data, [
+						'log',
+						'--tags',
+						'--simplify-by-decoration',
+						'--pretty=%S'
+					] );
 
 					if ( !commandOutput.logs.info.length ) {
 						throw new Error( `Can't check out the latest tag as package "${ data.packageName }" has no tags. Aborted.` );
@@ -99,13 +102,13 @@ export default {
 					checkoutValue = 'tags/' + data.repository.tag;
 				}
 
-				return execCommand.execute( getExecData( `git checkout "${ checkoutValue }"` ) );
+				return execCommand.executeGit( data, [ 'checkout', checkoutValue ] );
 			} )
 			.then( response => {
 				log.concat( response.logs );
 			} )
 			.then( () => {
-				return execCommand.execute( getExecData( 'git branch' ) );
+				return execCommand.executeGit( data, [ 'branch' ] );
 			} )
 			.then( response => {
 				const stdout = response.logs.info.join( '\n' ).trim();
@@ -118,7 +121,7 @@ export default {
 					return { logs: log.all() };
 				}
 
-				return execCommand.execute( getExecData( `git pull origin "${ data.repository.branch }"` ) )
+				return execCommand.executeGit( data, [ 'pull', 'origin', data.repository.branch ] )
 					.then( response => {
 						log.concat( response.logs );
 
@@ -134,12 +137,6 @@ export default {
 
 				return Promise.reject( { logs: log.all() } );
 			} );
-
-		function getExecData( command ) {
-			return Object.assign( {}, data, {
-				arguments: [ command ]
-			} );
-		}
 	},
 
 	/**
@@ -201,8 +198,16 @@ export default {
 	 */
 	_clonePackage( packageDetails, toolOptions, options ) {
 		const log = options.log;
+		const repositoryPath = upath.dirname( packageDetails.path );
 
-		return shell( `git clone --progress "${ packageDetails.url }" "${ packageDetails.path }"` )
+		return runGitCommand( [
+			'clone',
+			'--progress',
+			packageDetails.url,
+			packageDetails.path
+		], {
+			cwd: repositoryPath
+		} )
 			.then( async output => {
 				log.info( output );
 
@@ -211,9 +216,14 @@ export default {
 				if ( !packageDetails.tag ) {
 					checkoutValue = packageDetails.branch;
 				} else if ( packageDetails.tag === 'latest' ) {
-					const commandOutput = await shell(
-						`cd "${ packageDetails.path }" && git log --tags --simplify-by-decoration --pretty="%S"`
-					);
+					const commandOutput = await runGitCommand( [
+						'log',
+						'--tags',
+						'--simplify-by-decoration',
+						'--pretty=%S'
+					], {
+						cwd: packageDetails.path
+					} );
 					const latestTag = commandOutput.trim().split( '\n' ).shift();
 
 					checkoutValue = 'tags/' + latestTag.trim();
@@ -221,7 +231,9 @@ export default {
 					checkoutValue = 'tags/' + packageDetails.tag;
 				}
 
-				return shell( `cd "${ packageDetails.path }" && git checkout --quiet "${ checkoutValue }"` );
+				return runGitCommand( [ 'checkout', '--quiet', checkoutValue ], {
+					cwd: packageDetails.path
+				} );
 			} )
 			.then( async () => {
 				const commandOutput = {
@@ -254,7 +266,7 @@ export default {
 					} );
 				}
 
-				log.error( error.message );
+				log.error( error.message || error );
 
 				return Promise.reject( { logs: log.all() } );
 			} );

--- a/lib/utils/rungitcommand.js
+++ b/lib/utils/rungitcommand.js
@@ -1,0 +1,48 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { spawn } from 'node:child_process';
+
+/**
+ * Executes a git command using argument vectors (no shell interpolation).
+ *
+ * @param {Array.<String>} argumentsList Git command arguments without the leading "git".
+ * @param {Object} [options]
+ * @param {String} [options.cwd] Working directory where command should be executed.
+ * @returns {Promise.<String>} Resolves with command output (stderr + stdout).
+ */
+export function runGitCommand( argumentsList, options = {} ) {
+	return new Promise( ( resolve, reject ) => {
+		const child = spawn( 'git', argumentsList, {
+			cwd: options.cwd,
+			shell: false
+		} );
+
+		let stderr = '';
+		let stdout = '';
+
+		child.stderr.on( 'data', chunk => {
+			stderr += chunk.toString();
+		} );
+
+		child.stdout.on( 'data', chunk => {
+			stdout += chunk.toString();
+		} );
+
+		child.on( 'error', error => {
+			reject( error );
+		} );
+
+		child.on( 'close', code => {
+			const output = ( stderr + stdout ).trim();
+
+			if ( code === 0 ) {
+				return resolve( output );
+			}
+
+			return reject( output || `Git command exited with code ${ code }.` );
+		} );
+	} );
+}

--- a/tests/commands/checkout.js
+++ b/tests/commands/checkout.js
@@ -42,7 +42,7 @@ describe( 'commands/checkout', () => {
 		it( 'rejects promise if called command returned an error', () => {
 			const error = new Error( 'Unexpected error.' );
 
-			execCommand.execute.mockRejectedValue( {
+			execCommand.executeGit.mockRejectedValue( {
 				logs: {
 					error: [ error.stack ]
 				}
@@ -60,7 +60,7 @@ describe( 'commands/checkout', () => {
 		} );
 
 		it( 'checkouts to the correct branch', () => {
-			execCommand.execute.mockResolvedValue( {
+			execCommand.executeGit.mockResolvedValue( {
 				logs: {
 					info: [
 						'Already on \'master\'',
@@ -71,14 +71,11 @@ describe( 'commands/checkout', () => {
 
 			return checkoutCommand.execute( commandData )
 				.then( commandResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 1 );
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git checkout master' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 1 );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'checkout', 'master' ]
+					);
 
 					expect( commandResponse.logs.info ).toEqual( [
 						'Already on \'master\'',
@@ -90,7 +87,7 @@ describe( 'commands/checkout', () => {
 		it( 'checkouts to specified branch', () => {
 			commandData.arguments.push( 'develop' );
 
-			execCommand.execute.mockResolvedValue( {
+			execCommand.executeGit.mockResolvedValue( {
 				logs: {
 					info: [
 						'Switched to branch \'develop\'',
@@ -101,14 +98,11 @@ describe( 'commands/checkout', () => {
 
 			return checkoutCommand.execute( commandData )
 				.then( commandResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 1 );
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git checkout develop' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 1 );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'checkout', 'develop' ]
+					);
 
 					expect( commandResponse.logs.info ).toEqual( [
 						'Switched to branch \'develop\'',
@@ -120,7 +114,7 @@ describe( 'commands/checkout', () => {
 		it( 'creates a new branch if a repository has changes that could be committed and specified --branch option', () => {
 			toolOptions.branch = 'develop';
 
-			execCommand.execute
+			execCommand.executeGit
 				.mockResolvedValueOnce( {
 					logs: {
 						info: [
@@ -140,23 +134,17 @@ describe( 'commands/checkout', () => {
 
 			return checkoutCommand.execute( commandData )
 				.then( commandResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 2 );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 2 );
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git status --branch --porcelain' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'status', '--branch', '--porcelain' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 2, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git checkout -b develop' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2,
+						commandData,
+						[ 'checkout', '-b', 'develop' ]
+					);
 
 					expect( commandResponse.logs.info ).toEqual( [
 						'Switched to a new branch \'develop\''
@@ -167,7 +155,7 @@ describe( 'commands/checkout', () => {
 		it( 'does not create a branch if a repository has no-changes that could be committed when specified --branch option', () => {
 			toolOptions.branch = 'develop';
 
-			execCommand.execute.mockResolvedValueOnce( {
+			execCommand.executeGit.mockResolvedValueOnce( {
 				logs: {
 					info: [
 						'Response returned by "git status" command.'
@@ -179,19 +167,29 @@ describe( 'commands/checkout', () => {
 
 			return checkoutCommand.execute( commandData )
 				.then( commandResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 1 );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 1 );
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git status --branch --porcelain' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'status', '--branch', '--porcelain' ]
+					);
 
 					expect( commandResponse.logs.info ).toEqual( [
 						'Repository does not contain changes to commit. New branch was not created.'
 					] );
+				} );
+		} );
+
+		it( 'passes branch with special characters as a literal checkout argument', () => {
+			commandData.arguments.push( 'feature; touch HACKED; #' );
+			execCommand.executeGit.mockResolvedValue( { logs: { info: [ 'ok' ] } } );
+
+			return checkoutCommand.execute( commandData )
+				.then( () => {
+					expect( execCommand.executeGit ).toHaveBeenCalledWith(
+						commandData,
+						[ 'checkout', 'feature; touch HACKED; #' ]
+					);
 				} );
 		} );
 	} );

--- a/tests/commands/close.js
+++ b/tests/commands/close.js
@@ -48,7 +48,7 @@ describe( 'commands/close', () => {
 		it( 'rejects promise if called command returned an error', () => {
 			const error = new Error( 'Unexpected error.' );
 
-			execCommand.execute.mockRejectedValue( {
+			execCommand.executeGit.mockRejectedValue( {
 				logs: {
 					error: [ error.stack ]
 				}
@@ -68,7 +68,7 @@ describe( 'commands/close', () => {
 		it( 'merges specified branch and remove it from local and remote', () => {
 			commandData.arguments.push( 'develop' );
 
-			execCommand.execute
+			execCommand.executeGit
 				.mockResolvedValueOnce( { logs: {
 					info: [
 						'* develop'
@@ -103,47 +103,32 @@ describe( 'commands/close', () => {
 
 			return closeCommand.execute( commandData )
 				.then( commandResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 5 );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 5 );
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git branch --list develop' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'branch', '--list', 'develop' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 2, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git branch --show-current' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2,
+						commandData,
+						[ 'branch', '--show-current' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 3, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git merge develop --no-ff -m "Merge branch \'develop\'"' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 3,
+						commandData,
+						[ 'merge', 'develop', '--no-ff', '-m', 'Merge branch \'develop\'' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 4, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git branch -d develop' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 4,
+						commandData,
+						[ 'branch', '-d', 'develop' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 5, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git push origin :develop' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 5,
+						commandData,
+						[ 'push', 'origin', ':develop' ]
+					);
 
 					expect( commandResponse.logs.info ).toEqual( [
 						'Merge made by the \'recursive\' strategy.',
@@ -166,7 +151,7 @@ describe( 'commands/close', () => {
 			commandData.arguments.push( '--message' );
 			commandData.arguments.push( 'Test.' );
 
-			execCommand.execute
+			execCommand.executeGit
 				.mockResolvedValueOnce( { logs: {
 					info: [
 						'* develop'
@@ -201,47 +186,32 @@ describe( 'commands/close', () => {
 
 			return closeCommand.execute( commandData )
 				.then( commandResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 5 );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 5 );
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git branch --list develop' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'branch', '--list', 'develop' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 2, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git branch --show-current' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2,
+						commandData,
+						[ 'branch', '--show-current' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 3, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git merge develop --no-ff -m "Merge branch \'develop\'" -m "Test."' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 3,
+						commandData,
+						[ 'merge', 'develop', '--no-ff', '-m', 'Merge branch \'develop\'', '-m', 'Test.' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 4, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git branch -d develop' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 4,
+						commandData,
+						[ 'branch', '-d', 'develop' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 5, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git push origin :develop' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 5,
+						commandData,
+						[ 'push', 'origin', ':develop' ]
+					);
 
 					expect( commandResponse.logs.info ).toEqual( [
 						'Merge made by the \'recursive\' strategy.',
@@ -264,7 +234,7 @@ describe( 'commands/close', () => {
 
 			toolOptions.message = 'Test.';
 
-			execCommand.execute
+			execCommand.executeGit
 				.mockResolvedValueOnce( { logs: {
 					info: [
 						'* develop'
@@ -299,47 +269,32 @@ describe( 'commands/close', () => {
 
 			return closeCommand.execute( commandData )
 				.then( commandResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 5 );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 5 );
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git branch --list develop' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'branch', '--list', 'develop' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 2, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git branch --show-current' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2,
+						commandData,
+						[ 'branch', '--show-current' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 3, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git merge develop --no-ff -m "Merge branch \'develop\'" -m "Test."' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 3,
+						commandData,
+						[ 'merge', 'develop', '--no-ff', '-m', 'Merge branch \'develop\'', '-m', 'Test.' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 4, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git branch -d develop' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 4,
+						commandData,
+						[ 'branch', '-d', 'develop' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 5, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git push origin :develop' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 5,
+						commandData,
+						[ 'push', 'origin', ':develop' ]
+					);
 
 					expect( commandResponse.logs.info ).toEqual( [
 						'Merge made by the \'recursive\' strategy.',
@@ -361,7 +316,7 @@ describe( 'commands/close', () => {
 			commandData.arguments.push( '--message' );
 			commandData.arguments.push( 'Test.' );
 
-			execCommand.execute.mockResolvedValueOnce( {
+			execCommand.executeGit.mockResolvedValueOnce( {
 				logs: {
 					info: [
 						''
@@ -372,15 +327,12 @@ describe( 'commands/close', () => {
 
 			return closeCommand.execute( commandData )
 				.then( commandResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 1 );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 1 );
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git branch --list develop' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'branch', '--list', 'develop' ]
+					);
 
 					expect( commandResponse.logs.info ).toEqual( [
 						'Branch does not exist.'
@@ -391,7 +343,7 @@ describe( 'commands/close', () => {
 		it( 'does not merge branch if in detached head mode', () => {
 			commandData.arguments.push( 'develop' );
 
-			execCommand.execute
+			execCommand.executeGit
 				.mockResolvedValueOnce( { logs: {
 					info: [
 						'* develop'
@@ -407,27 +359,40 @@ describe( 'commands/close', () => {
 
 			return closeCommand.execute( commandData )
 				.then( commandResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 2 );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 2 );
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git branch --list develop' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'branch', '--list', 'develop' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 2, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git branch --show-current' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2,
+						commandData,
+						[ 'branch', '--show-current' ]
+					);
 
 					expect( commandResponse.logs.info ).toEqual( [
 						'This repository is currently in detached head mode - skipping.'
 					] );
+				} );
+		} );
+
+		it( 'passes branch name with shell-like tokens as a literal argument', () => {
+			commandData.arguments.push( 'develop; touch HACKED; #' );
+
+			execCommand.executeGit.mockResolvedValueOnce( {
+				logs: {
+					info: [ '' ],
+					error: []
+				}
+			} );
+
+			return closeCommand.execute( commandData )
+				.then( () => {
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'branch', '--list', 'develop; touch HACKED; #' ]
+					);
 				} );
 		} );
 	} );

--- a/tests/commands/commit.js
+++ b/tests/commands/commit.js
@@ -64,7 +64,7 @@ describe( 'commands/commit', () => {
 		it( 'rejects promise if called command returned an error', () => {
 			const error = new Error( 'Unexpected error.' );
 
-			execCommand.execute.mockRejectedValue( {
+			execCommand.executeGit.mockRejectedValue( {
 				logs: {
 					error: [ error.stack ]
 				}
@@ -84,7 +84,7 @@ describe( 'commands/commit', () => {
 		it( 'commits all changes', () => {
 			toolOptions.message = 'Test.';
 
-			execCommand.execute
+			execCommand.executeGit
 				.mockResolvedValueOnce( {
 					logs: {
 						info: [
@@ -104,23 +104,17 @@ describe( 'commands/commit', () => {
 
 			return commitCommand.execute( commandData )
 				.then( commandResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 2 );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 2 );
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git status --branch --porcelain' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'status', '--branch', '--porcelain' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 2, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git commit -a -m "Test."' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2,
+						commandData,
+						[ 'commit', '-a', '-m', 'Test.' ]
+					);
 
 					expect( commandResponse.logs.info ).toEqual( [
 						'[master a89f9ee] Test.'
@@ -132,7 +126,7 @@ describe( 'commands/commit', () => {
 			commandData.arguments.push( '--message' );
 			commandData.arguments.push( 'Test.' );
 
-			execCommand.execute
+			execCommand.executeGit
 				.mockResolvedValueOnce( {
 					logs: {
 						info: [
@@ -152,23 +146,17 @@ describe( 'commands/commit', () => {
 
 			return commitCommand.execute( commandData )
 				.then( commandResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 2 );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 2 );
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git status --branch --porcelain' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'status', '--branch', '--porcelain' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 2, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git commit -a -m "Test."' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2,
+						commandData,
+						[ 'commit', '-a', '-m', 'Test.' ]
+					);
 
 					expect( commandResponse.logs.info ).toEqual( [
 						'[master a89f9ee] Test.'
@@ -181,7 +169,7 @@ describe( 'commands/commit', () => {
 			commandData.arguments.push( '--message' );
 			commandData.arguments.push( 'Test' );
 
-			execCommand.execute
+			execCommand.executeGit
 				.mockResolvedValueOnce( {
 					logs: {
 						info: [
@@ -201,23 +189,17 @@ describe( 'commands/commit', () => {
 
 			return commitCommand.execute( commandData )
 				.then( commandResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 2 );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 2 );
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git status --branch --porcelain' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'status', '--branch', '--porcelain' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 2, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git commit -a -m "Test" -n' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2,
+						commandData,
+						[ 'commit', '-a', '-m', 'Test', '-n' ]
+					);
 
 					expect( commandResponse.logs.info ).toEqual( [
 						'[master a89f9ee] Test'
@@ -231,7 +213,7 @@ describe( 'commands/commit', () => {
 				'Foo.'
 			];
 
-			execCommand.execute
+			execCommand.executeGit
 				.mockResolvedValueOnce( {
 					logs: {
 						info: [
@@ -251,23 +233,17 @@ describe( 'commands/commit', () => {
 
 			return commitCommand.execute( commandData )
 				.then( commandResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 2 );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 2 );
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git status --branch --porcelain' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'status', '--branch', '--porcelain' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 2, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git commit -a -m "Test." -m "Foo."' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2,
+						commandData,
+						[ 'commit', '-a', '-m', 'Test.', '-m', 'Foo.' ]
+					);
 
 					expect( commandResponse.logs.info ).toEqual( [
 						'[master a89f9ee] Test.'
@@ -281,7 +257,7 @@ describe( 'commands/commit', () => {
 			commandData.arguments.push( '-m' );
 			commandData.arguments.push( 'Foo.' );
 
-			execCommand.execute
+			execCommand.executeGit
 				.mockResolvedValueOnce( {
 					logs: {
 						info: [
@@ -301,23 +277,17 @@ describe( 'commands/commit', () => {
 
 			return commitCommand.execute( commandData )
 				.then( commandResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 2 );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 2 );
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git status --branch --porcelain' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'status', '--branch', '--porcelain' ]
+					);
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 2, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git commit -a -m "Test." -m "Foo."' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2,
+						commandData,
+						[ 'commit', '-a', '-m', 'Test.', '-m', 'Foo.' ]
+					);
 
 					expect( commandResponse.logs.info ).toEqual( [
 						'[master a89f9ee] Test.'
@@ -329,7 +299,7 @@ describe( 'commands/commit', () => {
 			commandData.arguments.push( '--message' );
 			commandData.arguments.push( 'Test.' );
 
-			execCommand.execute.mockResolvedValueOnce( {
+			execCommand.executeGit.mockResolvedValueOnce( {
 				logs: {
 					info: [
 						'Response returned by "git status" command.'
@@ -341,15 +311,12 @@ describe( 'commands/commit', () => {
 
 			return commitCommand.execute( commandData )
 				.then( commandResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 1 );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 1 );
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git status --branch --porcelain' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'status', '--branch', '--porcelain' ]
+					);
 
 					expect( commandResponse.logs.info ).toEqual( [
 						'Nothing to commit.'
@@ -360,7 +327,7 @@ describe( 'commands/commit', () => {
 		it( 'does not commit if repository is in detached head mode', () => {
 			toolOptions.message = 'Test.';
 
-			execCommand.execute
+			execCommand.executeGit
 				.mockResolvedValueOnce( {
 					logs: {
 						info: [
@@ -380,19 +347,43 @@ describe( 'commands/commit', () => {
 
 			return commitCommand.execute( commandData )
 				.then( commandResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 1 );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 1 );
 
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, {
-						repository: {
-							branch: 'master'
-						},
-						arguments: [ 'git status --branch --porcelain' ],
-						toolOptions
-					} );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'status', '--branch', '--porcelain' ]
+					);
 
 					expect( commandResponse.logs.info ).toEqual( [
 						'This repository is currently in detached head mode - skipping.'
 					] );
+				} );
+		} );
+
+		it( 'passes message with shell-like content as a literal argument', () => {
+			commandData.arguments.push( '--message' );
+			commandData.arguments.push( 'Test; touch HACKED; #' );
+
+			execCommand.executeGit
+				.mockResolvedValueOnce( {
+					logs: {
+						info: [ 'Response returned by "git status" command.' ]
+					}
+				} )
+				.mockResolvedValueOnce( {
+					logs: {
+						info: [ '[master a89f9ee] Test; touch HACKED; #' ]
+					}
+				} );
+
+			gitStatusParser.mockReturnValue( { anythingToCommit: true } );
+
+			return commitCommand.execute( commandData )
+				.then( () => {
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2,
+						commandData,
+						[ 'commit', '-a', '-m', 'Test; touch HACKED; #' ]
+					);
 				} );
 		} );
 	} );

--- a/tests/commands/diff.js
+++ b/tests/commands/diff.js
@@ -39,7 +39,7 @@ describe( 'commands/diff', () => {
 		it( 'rejects promise if called command returned an error', () => {
 			const error = new Error( 'Unexpected error.' );
 
-			execCommand.execute.mockRejectedValue( {
+			execCommand.executeGit.mockRejectedValue( {
 				logs: {
 					error: [ error.stack ]
 				}
@@ -67,7 +67,7 @@ describe( 'commands/diff', () => {
 				' gulp.task( \'pre-commit\', [ \'lint-staged\' ] );\n' +
 				'+// Some comment.';
 
-			execCommand.execute.mockResolvedValue( {
+			execCommand.executeGit.mockResolvedValue( {
 				logs: {
 					info: [ diffResult ]
 				}
@@ -75,9 +75,10 @@ describe( 'commands/diff', () => {
 
 			return diffCommand.execute( commandData )
 				.then( diffResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 1 );
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1,
-						expect.objectContaining( { arguments: [ 'git diff --color' ] } )
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 1 );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'diff', '--color' ]
 					);
 
 					expect( diffResponse.logs.info[ 0 ] ).toEqual( diffResult );
@@ -85,18 +86,18 @@ describe( 'commands/diff', () => {
 		} );
 
 		it( 'does not return the logs when repository has not changed', () => {
-			execCommand.execute.mockResolvedValue( { logs: { info: [] } } );
+			execCommand.executeGit.mockResolvedValue( { logs: { info: [] } } );
 
 			return diffCommand.execute( commandData )
 				.then( diffResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 1 );
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 1 );
 
 					expect( diffResponse ).toEqual( {} );
 				} );
 		} );
 
 		it( 'allows modifying the "git diff" command', () => {
-			execCommand.execute.mockResolvedValue( { logs: { info: [] } } );
+			execCommand.executeGit.mockResolvedValue( { logs: { info: [] } } );
 
 			commandData.arguments = [
 				'--stat',
@@ -105,12 +106,27 @@ describe( 'commands/diff', () => {
 
 			return diffCommand.execute( commandData )
 				.then( diffResponse => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 1 );
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1,
-						expect.objectContaining( { arguments: [ 'git diff --color --stat --staged' ] } )
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 1 );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'diff', '--color', '--stat', '--staged' ]
 					);
 
 					expect( diffResponse ).toEqual( {} );
+				} );
+		} );
+
+		it( 'treats special characters in arguments as literal values', () => {
+			execCommand.executeGit.mockResolvedValue( { logs: { info: [] } } );
+
+			commandData.arguments = [ 'origin/master; touch HACKED; #' ];
+
+			return diffCommand.execute( commandData )
+				.then( () => {
+					expect( execCommand.executeGit ).toHaveBeenCalledWith(
+						commandData,
+						[ 'diff', '--color', 'origin/master; touch HACKED; #' ]
+					);
 				} );
 		} );
 	} );

--- a/tests/commands/exec.js
+++ b/tests/commands/exec.js
@@ -6,9 +6,11 @@
 import { vi, beforeEach, describe, it, expect } from 'vitest';
 import execCommand from '../../lib/commands/exec.js';
 import { shell } from '../../lib/utils/shell.js';
+import { runGitCommand } from '../../lib/utils/rungitcommand.js';
 import fs from 'node:fs';
 
 vi.mock( '../../lib/utils/shell.js' );
+vi.mock( '../../lib/utils/rungitcommand.js' );
 vi.mock( 'fs' );
 
 describe( 'commands/exec', () => {
@@ -101,6 +103,94 @@ describe( 'commands/exec', () => {
 					expect( chdir ).toHaveBeenNthCalledWith( 2, import.meta.dirname );
 					expect( response.logs.info[ 0 ] ).toEqual( pwd );
 				} );
+		} );
+	} );
+
+	describe( 'executeGit()', () => {
+		it( 'does not execute git command if package is not available', () => {
+			fs.existsSync.mockReturnValue( false );
+
+			return execCommand.executeGit( commandData, [ 'status', '-s' ] )
+				.then(
+					() => {
+						throw new Error( 'Supposed to be rejected.' );
+					},
+					response => {
+						expect( runGitCommand ).not.toHaveBeenCalled();
+
+						const err = 'Package "test-package" is not available. Run "mrgit sync" in order to download the package.';
+						expect( response.logs.error[ 0 ] ).toEqual( err );
+					}
+				);
+		} );
+
+		it( 'uses package path as cwd for non-root repository', () => {
+			const commandOutput = 'On branch master';
+
+			fs.existsSync.mockReturnValue( true );
+			runGitCommand.mockResolvedValue( commandOutput );
+
+			return execCommand.executeGit( commandData, [ 'status', '-s' ] )
+				.then( response => {
+					expect( runGitCommand ).toHaveBeenCalledTimes( 1 );
+					expect( runGitCommand ).toHaveBeenNthCalledWith( 1,
+						[ 'status', '-s' ],
+						{ cwd: 'packages/test-package' }
+					);
+					expect( response.logs.info[ 0 ] ).toEqual( commandOutput );
+				} );
+		} );
+
+		it( 'uses tool cwd as cwd for root repository', () => {
+			const commandOutput = 'root output';
+
+			commandData.isRootRepository = true;
+			fs.existsSync.mockReturnValue( true );
+			runGitCommand.mockResolvedValue( commandOutput );
+
+			return execCommand.executeGit( commandData, [ 'status', '-s' ] )
+				.then( response => {
+					expect( runGitCommand ).toHaveBeenCalledTimes( 1 );
+					expect( runGitCommand ).toHaveBeenNthCalledWith( 1,
+						[ 'status', '-s' ],
+						{ cwd: import.meta.dirname }
+					);
+					expect( response.logs.info[ 0 ] ).toEqual( commandOutput );
+				} );
+		} );
+
+		it( 'rejects promise when git command throws error object', () => {
+			const error = new Error( 'Unexpected error.' );
+
+			fs.existsSync.mockReturnValue( true );
+			runGitCommand.mockRejectedValue( error );
+
+			return execCommand.executeGit( commandData, [ 'status', '-s' ] )
+				.then(
+					() => {
+						throw new Error( 'Supposed to be rejected.' );
+					},
+					response => {
+						expect( response.logs.error[ 0 ] ).toEqual( error.message );
+					}
+				);
+		} );
+
+		it( 'rejects promise when git command throws string', () => {
+			const error = 'fatal: Unexpected error.';
+
+			fs.existsSync.mockReturnValue( true );
+			runGitCommand.mockRejectedValue( error );
+
+			return execCommand.executeGit( commandData, [ 'status', '-s' ] )
+				.then(
+					() => {
+						throw new Error( 'Supposed to be rejected.' );
+					},
+					response => {
+						expect( response.logs.error[ 0 ] ).toEqual( error );
+					}
+				);
 		} );
 	} );
 } );

--- a/tests/commands/push.js
+++ b/tests/commands/push.js
@@ -49,15 +49,16 @@ describe( 'commands/push', () => {
 		it( 'skips a package if its in detached head mode', () => {
 			fs.existsSync.mockReturnValue( true );
 
-			execCommand.execute.mockReturnValueOnce( Promise.resolve( {
+			execCommand.executeGit.mockReturnValueOnce( Promise.resolve( {
 				logs: getCommandLogs( '' )
 			} ) );
 
 			return pushCommand.execute( commandData )
 				.then( response => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 1 );
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1,
-						expect.objectContaining( { arguments: [ 'git branch --show-current' ] } )
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 1 );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'branch', '--show-current' ]
 					);
 
 					expect( response.logs.info ).toEqual( [
@@ -69,7 +70,7 @@ describe( 'commands/push', () => {
 		it( 'resolves promise after pushing the changes', () => {
 			fs.existsSync.mockReturnValue( true );
 
-			execCommand.execute
+			execCommand.executeGit
 				.mockResolvedValueOnce( {
 					logs: getCommandLogs( 'master' )
 				} )
@@ -79,12 +80,14 @@ describe( 'commands/push', () => {
 
 			return pushCommand.execute( commandData )
 				.then( response => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 2 );
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1,
-						expect.objectContaining( { arguments: [ 'git branch --show-current' ] } )
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 2 );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'branch', '--show-current' ]
 					);
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 2,
-						expect.objectContaining( { arguments: [ 'git push' ] } )
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2,
+						commandData,
+						[ 'push' ]
 					);
 
 					expect( response.logs.info ).toEqual( [
@@ -98,23 +101,42 @@ describe( 'commands/push', () => {
 			commandData.arguments.push( '--all' );
 			fs.existsSync.mockReturnValue( true );
 
-			execCommand.execute.mockReturnValue( Promise.resolve( {
+			execCommand.executeGit.mockReturnValue( Promise.resolve( {
 				logs: getCommandLogs( 'Everything up-to-date' )
 			} ) );
 
 			return pushCommand.execute( commandData )
 				.then( response => {
-					expect( execCommand.execute ).toHaveBeenCalledTimes( 2 );
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 1,
-						expect.objectContaining( { arguments: [ 'git branch --show-current' ] } )
+					expect( execCommand.executeGit ).toHaveBeenCalledTimes( 2 );
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1,
+						commandData,
+						[ 'branch', '--show-current' ]
 					);
-					expect( execCommand.execute ).toHaveBeenNthCalledWith( 2,
-						expect.objectContaining( { arguments: [ 'git push --verbose --all' ] } )
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2,
+						commandData,
+						[ 'push', '--verbose', '--all' ]
 					);
 
 					expect( response.logs.info ).toEqual( [
 						'Everything up-to-date'
 					] );
+				} );
+		} );
+
+		it( 'passes shell-like fragments as plain push arguments', () => {
+			commandData.arguments.push( 'origin; touch HACKED; #' );
+			fs.existsSync.mockReturnValue( true );
+
+			execCommand.executeGit
+				.mockResolvedValueOnce( { logs: getCommandLogs( 'master' ) } )
+				.mockResolvedValueOnce( { logs: getCommandLogs( 'Everything up-to-date' ) } );
+
+			return pushCommand.execute( commandData )
+				.then( () => {
+					expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2,
+						commandData,
+						[ 'push', 'origin; touch HACKED; #' ]
+					);
 				} );
 		} );
 	} );

--- a/tests/commands/sync.js
+++ b/tests/commands/sync.js
@@ -6,12 +6,12 @@
 import { vi, describe, beforeEach, afterEach, it, expect } from 'vitest';
 import syncCommand from '../../lib/commands/sync.js';
 import execCommand from '../../lib/commands/exec.js';
-import { shell } from '../../lib/utils/shell.js';
+import { runGitCommand } from '../../lib/utils/rungitcommand.js';
 import { pathToFileURL } from 'node:url';
 import fs from 'node:fs';
 
 vi.mock( '../../lib/commands/exec.js' );
-vi.mock( '../../lib/utils/shell.js' );
+vi.mock( '../../lib/utils/rungitcommand.js' );
 vi.mock( 'fs' );
 vi.mock( 'url' );
 
@@ -55,19 +55,21 @@ describe( 'commands/sync', () => {
 		describe( 'first call on a package', () => {
 			it( 'clones the repository if is not available', () => {
 				fs.existsSync.mockReturnValue( false );
-				shell.mockReturnValue( Promise.resolve( 'Git clone log.' ) );
+				runGitCommand.mockReturnValue( Promise.resolve( 'Git clone log.' ) );
 
 				return syncCommand.execute( commandData )
 					.then( response => {
-						expect( shell ).toHaveBeenCalledTimes( 2 );
+						expect( runGitCommand ).toHaveBeenCalledTimes( 2 );
 
 						// Clone the repository.
-						expect( shell ).toHaveBeenNthCalledWith( 1,
-							'git clone --progress "git@github.com/organization/test-package.git" "/tmp/packages/test-package"'
+						expect( runGitCommand ).toHaveBeenNthCalledWith( 1,
+							[ 'clone', '--progress', 'git@github.com/organization/test-package.git', '/tmp/packages/test-package' ],
+							{ cwd: '/tmp/packages' }
 						);
 						// Change the directory to cloned package and check out to proper branch.
-						expect( shell ).toHaveBeenNthCalledWith( 2,
-							'cd "/tmp/packages/test-package" && git checkout --quiet "master"'
+						expect( runGitCommand ).toHaveBeenNthCalledWith( 2,
+							[ 'checkout', '--quiet', 'master' ],
+							{ cwd: '/tmp/packages/test-package' }
 						);
 
 						expect( response.logs.info ).toEqual( [
@@ -81,19 +83,21 @@ describe( 'commands/sync', () => {
 				commandData.repository.tag = 'v30.0.0';
 
 				fs.existsSync.mockReturnValue( false );
-				shell.mockReturnValue( Promise.resolve( 'Git clone log.' ) );
+				runGitCommand.mockReturnValue( Promise.resolve( 'Git clone log.' ) );
 
 				return syncCommand.execute( commandData )
 					.then( response => {
-						expect( shell ).toHaveBeenCalledTimes( 2 );
+						expect( runGitCommand ).toHaveBeenCalledTimes( 2 );
 
 						// Clone the repository.
-						expect( shell ).toHaveBeenNthCalledWith( 1,
-							'git clone --progress "git@github.com/organization/test-package.git" "/tmp/packages/test-package"'
+						expect( runGitCommand ).toHaveBeenNthCalledWith( 1,
+							[ 'clone', '--progress', 'git@github.com/organization/test-package.git', '/tmp/packages/test-package' ],
+							{ cwd: '/tmp/packages' }
 						);
 						// Change the directory to cloned package and check out to proper branch.
-						expect( shell ).toHaveBeenNthCalledWith( 2,
-							'cd "/tmp/packages/test-package" && git checkout --quiet "tags/v30.0.0"'
+						expect( runGitCommand ).toHaveBeenNthCalledWith( 2,
+							[ 'checkout', '--quiet', 'tags/v30.0.0' ],
+							{ cwd: '/tmp/packages/test-package' }
 						);
 
 						expect( response.logs.info ).toEqual( [
@@ -106,11 +110,14 @@ describe( 'commands/sync', () => {
 			it( 'clones the repository and checks the latest tag', () => {
 				commandData.repository.tag = 'latest';
 
-				const command = 'cd "/tmp/packages/test-package" && git log --tags --simplify-by-decoration --pretty="%S"';
+				const command = [ 'log', '--tags', '--simplify-by-decoration', '--pretty=%S' ];
 
 				fs.existsSync.mockReturnValue( false );
-				shell.mockImplementation( shellArg => {
-					if ( shellArg === command ) {
+				runGitCommand.mockImplementation( ( commandArguments, options ) => {
+					if (
+						options.cwd === '/tmp/packages/test-package' &&
+						JSON.stringify( commandArguments ) === JSON.stringify( command )
+					) {
 						return Promise.resolve( 'v35.3.2\nv35.3.1\nv35.3.0\nv35.2.1\nv35.2.0' );
 					}
 
@@ -119,17 +126,19 @@ describe( 'commands/sync', () => {
 
 				return syncCommand.execute( commandData )
 					.then( response => {
-						expect( shell ).toHaveBeenCalledTimes( 3 );
+						expect( runGitCommand ).toHaveBeenCalledTimes( 3 );
 
 						// Clone the repository.
-						expect( shell ).toHaveBeenNthCalledWith( 1,
-							'git clone --progress "git@github.com/organization/test-package.git" "/tmp/packages/test-package"'
+						expect( runGitCommand ).toHaveBeenNthCalledWith( 1,
+							[ 'clone', '--progress', 'git@github.com/organization/test-package.git', '/tmp/packages/test-package' ],
+							{ cwd: '/tmp/packages' }
 						);
 						// Look for the latest tag.
-						expect( shell ).toHaveBeenNthCalledWith( 2, command );
+						expect( runGitCommand ).toHaveBeenNthCalledWith( 2, command, { cwd: '/tmp/packages/test-package' } );
 						// Change the directory to cloned package and check out to proper branch.
-						expect( shell ).toHaveBeenNthCalledWith( 3,
-							'cd "/tmp/packages/test-package" && git checkout --quiet "tags/v35.3.2"'
+						expect( runGitCommand ).toHaveBeenNthCalledWith( 3,
+							[ 'checkout', '--quiet', 'tags/v35.3.2' ],
+							{ cwd: '/tmp/packages/test-package' }
 						);
 
 						expect( response.logs.info ).toEqual( [
@@ -145,7 +154,7 @@ describe( 'commands/sync', () => {
 				commandData.repository.directory = 'project-a';
 
 				fs.existsSync.mockReturnValue( false );
-				shell.mockReturnValue( Promise.resolve( 'Git clone log.' ) );
+				runGitCommand.mockReturnValue( Promise.resolve( 'Git clone log.' ) );
 
 				return syncCommand.execute( commandData )
 					.then( response => {
@@ -160,7 +169,7 @@ describe( 'commands/sync', () => {
 				commandData.repository.directory = 'project-with-options-in-mrgitjson';
 
 				fs.existsSync.mockReturnValue( false );
-				shell.mockReturnValue( Promise.resolve( 'Git clone log.' ) );
+				runGitCommand.mockReturnValue( Promise.resolve( 'Git clone log.' ) );
 
 				return syncCommand.execute( commandData )
 					.then( response => {
@@ -173,7 +182,7 @@ describe( 'commands/sync', () => {
 				it( 'for errors with capital letters', async () => {
 					fs.existsSync.mockReturnValue( false );
 
-					shell
+					runGitCommand
 						.mockRejectedValueOnce( [
 							'exec: Cloning into \'/some/path\'...',
 							'remote: Enumerating objects: 6, done.',
@@ -192,22 +201,25 @@ describe( 'commands/sync', () => {
 
 					return promise
 						.then( response => {
-							expect( shell ).toHaveBeenCalledTimes( 3 );
+							expect( runGitCommand ).toHaveBeenCalledTimes( 3 );
 
 							// First attempt.
 							// Clone the repository.
-							expect( shell ).toHaveBeenNthCalledWith( 1,
-								'git clone --progress "git@github.com/organization/test-package.git" "/tmp/packages/test-package"'
+							expect( runGitCommand ).toHaveBeenNthCalledWith( 1,
+								[ 'clone', '--progress', 'git@github.com/organization/test-package.git', '/tmp/packages/test-package' ],
+								{ cwd: '/tmp/packages' }
 							);
 
 							// Second attempt.
 							// Clone the repository.
-							expect( shell ).toHaveBeenNthCalledWith( 2,
-								'git clone --progress "git@github.com/organization/test-package.git" "/tmp/packages/test-package"'
+							expect( runGitCommand ).toHaveBeenNthCalledWith( 2,
+								[ 'clone', '--progress', 'git@github.com/organization/test-package.git', '/tmp/packages/test-package' ],
+								{ cwd: '/tmp/packages' }
 							);
 							// Change the directory to cloned package and check out to proper branch.
-							expect( shell ).toHaveBeenNthCalledWith( 3,
-								'cd "/tmp/packages/test-package" && git checkout --quiet "master"'
+							expect( runGitCommand ).toHaveBeenNthCalledWith( 3,
+								[ 'checkout', '--quiet', 'master' ],
+								{ cwd: '/tmp/packages/test-package' }
 							);
 
 							expect( response.logs.info ).toEqual( [
@@ -220,7 +232,7 @@ describe( 'commands/sync', () => {
 				it( 'for errors with small letters', async () => {
 					fs.existsSync.mockReturnValue( false );
 
-					shell
+					runGitCommand
 						.mockRejectedValueOnce( [
 							'exec: Cloning into \'/some/path\'...',
 							'remote: Enumerating objects: 6, done.',
@@ -239,22 +251,25 @@ describe( 'commands/sync', () => {
 
 					return promise
 						.then( response => {
-							expect( shell ).toHaveBeenCalledTimes( 3 );
+							expect( runGitCommand ).toHaveBeenCalledTimes( 3 );
 
 							// First attempt.
 							// Clone the repository.
-							expect( shell ).toHaveBeenNthCalledWith( 1,
-								'git clone --progress "git@github.com/organization/test-package.git" "/tmp/packages/test-package"'
+							expect( runGitCommand ).toHaveBeenNthCalledWith( 1,
+								[ 'clone', '--progress', 'git@github.com/organization/test-package.git', '/tmp/packages/test-package' ],
+								{ cwd: '/tmp/packages' }
 							);
 
 							// Second attempt.
 							// Clone the repository.
-							expect( shell ).toHaveBeenNthCalledWith( 2,
-								'git clone --progress "git@github.com/organization/test-package.git" "/tmp/packages/test-package"'
+							expect( runGitCommand ).toHaveBeenNthCalledWith( 2,
+								[ 'clone', '--progress', 'git@github.com/organization/test-package.git', '/tmp/packages/test-package' ],
+								{ cwd: '/tmp/packages' }
 							);
 							// Change the directory to cloned package and check out to proper branch.
-							expect( shell ).toHaveBeenNthCalledWith( 3,
-								'cd "/tmp/packages/test-package" && git checkout --quiet "master"'
+							expect( runGitCommand ).toHaveBeenNthCalledWith( 3,
+								[ 'checkout', '--quiet', 'master' ],
+								{ cwd: '/tmp/packages/test-package' }
 							);
 
 							expect( response.logs.info ).toEqual( [
@@ -278,7 +293,7 @@ describe( 'commands/sync', () => {
 						'fatal: index-pack failed'
 					].join( '\n' );
 
-					shell
+					runGitCommand
 						.mockRejectedValueOnce( new Error( errorMessage ) )
 						.mockRejectedValueOnce( new Error( errorMessage ) );
 
@@ -302,7 +317,7 @@ describe( 'commands/sync', () => {
 								throw new Error( 'Expected that the Promise fails.' );
 							},
 							response => {
-								expect( shell ).toHaveBeenCalledTimes( 2 );
+								expect( runGitCommand ).toHaveBeenCalledTimes( 2 );
 
 								expect( response.logs.info ).toEqual( [
 									'Package "test-package" was not found. Cloning...'
@@ -321,7 +336,7 @@ describe( 'commands/sync', () => {
 			it( 'resolves promise after pulling the changes', () => {
 				fs.existsSync.mockReturnValue( true );
 
-				execCommand.execute
+				execCommand.executeGit
 					.mockResolvedValueOnce( {
 						logs: getCommandLogs( '' )
 					} )
@@ -340,28 +355,18 @@ describe( 'commands/sync', () => {
 
 				return syncCommand.execute( commandData )
 					.then( response => {
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, expect.objectContaining(
-							{ arguments: [ 'git status -s' ] }
-						) );
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 2, expect.objectContaining(
-							{ arguments: [ 'git fetch' ] }
-						) );
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 3, expect.objectContaining(
-							{ arguments: [ 'git checkout "master"' ] }
-						) );
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 4, expect.objectContaining(
-							{ arguments: [ 'git branch' ] }
-						) );
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 5, expect.objectContaining(
-							{ arguments: [ 'git pull origin "master"' ] }
-						) );
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1, commandData, [ 'status', '-s' ] );
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2, commandData, [ 'fetch' ] );
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 3, commandData, [ 'checkout', 'master' ] );
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 4, commandData, [ 'branch' ] );
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 5, commandData, [ 'pull', 'origin', 'master' ] );
 
 						expect( response.logs.info ).toEqual( [
 							'Already on \'master\'.',
 							'Already up-to-date.'
 						] );
 
-						expect( execCommand.execute ).toHaveBeenCalledTimes( 5 );
+						expect( execCommand.executeGit ).toHaveBeenCalledTimes( 5 );
 					} );
 			} );
 
@@ -370,7 +375,7 @@ describe( 'commands/sync', () => {
 
 				fs.existsSync.mockReturnValue( true );
 
-				execCommand.execute
+				execCommand.executeGit
 					.mockResolvedValueOnce( {
 						logs: getCommandLogs( '' )
 					} )
@@ -392,25 +397,17 @@ describe( 'commands/sync', () => {
 
 				return syncCommand.execute( commandData )
 					.then( response => {
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, expect.objectContaining(
-							{ arguments: [ 'git status -s' ] }
-						) );
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 2, expect.objectContaining(
-							{ arguments: [ 'git fetch' ] }
-						) );
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 3, expect.objectContaining(
-							{ arguments: [ 'git checkout "tags/v35.3.0"' ] }
-						) );
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 4, expect.objectContaining(
-							{ arguments: [ 'git branch' ] }
-						) );
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1, commandData, [ 'status', '-s' ] );
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2, commandData, [ 'fetch' ] );
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 3, commandData, [ 'checkout', 'tags/v35.3.0' ] );
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 4, commandData, [ 'branch' ] );
 
 						expect( response.logs.info ).toEqual( [
 							'Note: checking out \'tags/v35.3.0\'.',
 							'Package "test-package" is on a detached commit.'
 						] );
 
-						expect( execCommand.execute ).toHaveBeenCalledTimes( 4 );
+						expect( execCommand.executeGit ).toHaveBeenCalledTimes( 4 );
 					} );
 			} );
 
@@ -419,7 +416,7 @@ describe( 'commands/sync', () => {
 
 				fs.existsSync.mockReturnValue( true );
 
-				execCommand.execute
+				execCommand.executeGit
 					.mockResolvedValueOnce( {
 						logs: getCommandLogs( '' )
 					} )
@@ -444,28 +441,22 @@ describe( 'commands/sync', () => {
 
 				return syncCommand.execute( commandData )
 					.then( response => {
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, expect.objectContaining(
-							{ arguments: [ 'git status -s' ] }
-						) );
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 2, expect.objectContaining(
-							{ arguments: [ 'git fetch' ] }
-						) );
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 3, expect.objectContaining(
-							{ arguments: [ 'git log --tags --simplify-by-decoration --pretty="%S"' ] }
-						) );
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 4, expect.objectContaining(
-							{ arguments: [ 'git checkout "tags/v35.3.2"' ] }
-						) );
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 5, expect.objectContaining(
-							{ arguments: [ 'git branch' ] }
-						) );
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1, commandData, [ 'status', '-s' ] );
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2, commandData, [ 'fetch' ] );
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith(
+							3,
+							commandData,
+							[ 'log', '--tags', '--simplify-by-decoration', '--pretty=%S' ]
+						);
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 4, commandData, [ 'checkout', 'tags/v35.3.2' ] );
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 5, commandData, [ 'branch' ] );
 
 						expect( response.logs.info ).toEqual( [
 							'Note: checking out \'tags/v35.3.2\'.',
 							'Package "test-package" is on a detached commit.'
 						] );
 
-						expect( execCommand.execute ).toHaveBeenCalledTimes( 5 );
+						expect( execCommand.executeGit ).toHaveBeenCalledTimes( 5 );
 					} );
 			} );
 
@@ -474,7 +465,7 @@ describe( 'commands/sync', () => {
 
 				fs.existsSync.mockReturnValue( true );
 
-				execCommand.execute
+				execCommand.executeGit
 					.mockResolvedValueOnce( {
 						logs: getCommandLogs( '' )
 					} )
@@ -490,17 +481,15 @@ describe( 'commands/sync', () => {
 						throw new Error( 'Expected to throw' );
 					} )
 					.catch( response => {
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, expect.objectContaining(
-							{ arguments: [ 'git status -s' ] }
-						) );
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 2, expect.objectContaining(
-							{ arguments: [ 'git fetch' ] }
-						) );
-						expect( execCommand.execute ).toHaveBeenNthCalledWith( 3, expect.objectContaining(
-							{ arguments: [ 'git log --tags --simplify-by-decoration --pretty="%S"' ] }
-						) );
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1, commandData, [ 'status', '-s' ] );
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 2, commandData, [ 'fetch' ] );
+						expect( execCommand.executeGit ).toHaveBeenNthCalledWith(
+							3,
+							commandData,
+							[ 'log', '--tags', '--simplify-by-decoration', '--pretty=%S' ]
+						);
 
-						expect( execCommand.execute ).toHaveBeenCalledTimes( 3 );
+						expect( execCommand.executeGit ).toHaveBeenCalledTimes( 3 );
 
 						expect( response.logs.error[ 0 ] ).toEqual(
 							'Can\'t check out the latest tag as package "test-package" has no tags. Aborted.'
@@ -511,7 +500,7 @@ describe( 'commands/sync', () => {
 			it( 'aborts if package has uncommitted changes', () => {
 				fs.existsSync.mockReturnValue( true );
 
-				execCommand.execute.mockReturnValue( Promise.resolve( {
+				execCommand.executeGit.mockReturnValue( Promise.resolve( {
 					logs: getCommandLogs( ' M first-file.js\n ?? second-file.js' )
 				} ) );
 
@@ -524,9 +513,7 @@ describe( 'commands/sync', () => {
 							const errMsg = 'Package "test-package" has uncommitted changes. Aborted.';
 
 							expect( response.logs.error[ 0 ].split( '\n' )[ 0 ] ).toEqual( errMsg );
-							expect( execCommand.execute ).toHaveBeenNthCalledWith( 1, expect.objectContaining(
-								{ arguments: [ 'git status -s' ] }
-							) );
+							expect( execCommand.executeGit ).toHaveBeenNthCalledWith( 1, commandData, [ 'status', '-s' ] );
 						}
 					);
 			} );
@@ -536,7 +523,7 @@ describe( 'commands/sync', () => {
 
 				commandData.repository.branch = '1a0ff0a';
 
-				execCommand.execute
+				execCommand.executeGit
 					.mockResolvedValueOnce( {
 						logs: getCommandLogs( '' )
 					} )
@@ -560,7 +547,7 @@ describe( 'commands/sync', () => {
 							'Package "test-package" is on a detached commit.'
 						] );
 
-						expect( execCommand.execute ).toHaveBeenCalledTimes( 4 );
+						expect( execCommand.executeGit ).toHaveBeenCalledTimes( 4 );
 					} );
 			} );
 
@@ -569,7 +556,7 @@ describe( 'commands/sync', () => {
 
 				commandData.repository.branch = 'develop';
 
-				execCommand.execute
+				execCommand.executeGit
 					.mockResolvedValueOnce( {
 						logs: getCommandLogs( '' )
 					} )
@@ -599,7 +586,7 @@ describe( 'commands/sync', () => {
 							const errMsg = 'fatal: Couldn\'t find remote ref develop';
 							expect( response.logs.error[ 0 ].split( '\n' )[ 0 ] ).toEqual( errMsg );
 
-							expect( execCommand.execute ).toHaveBeenCalledTimes( 5 );
+							expect( execCommand.executeGit ).toHaveBeenCalledTimes( 5 );
 						}
 					);
 			} );
@@ -609,7 +596,7 @@ describe( 'commands/sync', () => {
 
 				commandData.repository.branch = 'non-existing-branch';
 
-				execCommand.execute
+				execCommand.executeGit
 					.mockResolvedValueOnce( {
 						logs: getCommandLogs( '' )
 					} )
@@ -629,7 +616,7 @@ describe( 'commands/sync', () => {
 							const errMsg = 'error: pathspec \'ggdfgd\' did not match any file(s) known to git.';
 							expect( response.logs.error[ 0 ].split( '\n' )[ 0 ] ).toEqual( errMsg );
 
-							expect( execCommand.execute ).toHaveBeenCalledTimes( 3 );
+							expect( execCommand.executeGit ).toHaveBeenCalledTimes( 3 );
 						}
 					);
 			} );

--- a/tests/utils/rungitcommand.js
+++ b/tests/utils/rungitcommand.js
@@ -1,0 +1,83 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { vi, beforeEach, describe, it, expect } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { spawn } from 'node:child_process';
+import { runGitCommand } from '../../lib/utils/rungitcommand.js';
+
+vi.mock( 'node:child_process' );
+
+describe( 'utils', () => {
+	describe( 'runGitCommand()', () => {
+		let child;
+
+		beforeEach( () => {
+			child = createMockChildProcess();
+			spawn.mockReturnValue( child );
+		} );
+
+		it( 'executes git command with shell interpolation disabled', async () => {
+			const commandPromise = runGitCommand( [ 'status', '-s' ], { cwd: '/tmp/packages/test-package' } );
+
+			expect( spawn ).toHaveBeenCalledTimes( 1 );
+			expect( spawn ).toHaveBeenNthCalledWith( 1,
+				'git',
+				[ 'status', '-s' ],
+				{ cwd: '/tmp/packages/test-package', shell: false }
+			);
+
+			child.stdout.emit( 'data', Buffer.from( 'On branch master\n' ) );
+			child.emit( 'close', 0 );
+
+			await expect( commandPromise ).resolves.toEqual( 'On branch master' );
+		} );
+
+		it( 'resolves with stderr and stdout output', async () => {
+			const commandPromise = runGitCommand( [ 'fetch' ] );
+
+			child.stderr.emit( 'data', Buffer.from( 'warning\n' ) );
+			child.stdout.emit( 'data', Buffer.from( 'done\n' ) );
+			child.emit( 'close', 0 );
+
+			await expect( commandPromise ).resolves.toEqual( 'warning\ndone' );
+		} );
+
+		it( 'rejects with output for failed command', async () => {
+			const commandPromise = runGitCommand( [ 'checkout', 'unknown-branch' ] );
+
+			child.stderr.emit( 'data', Buffer.from( 'error: pathspec did not match\n' ) );
+			child.emit( 'close', 1 );
+
+			await expect( commandPromise ).rejects.toEqual( 'error: pathspec did not match' );
+		} );
+
+		it( 'rejects with fallback message when failed command has no output', async () => {
+			const commandPromise = runGitCommand( [ 'checkout', 'unknown-branch' ] );
+
+			child.emit( 'close', 2 );
+
+			await expect( commandPromise ).rejects.toEqual( 'Git command exited with code 2.' );
+		} );
+
+		it( 'rejects when spawn emits an error', async () => {
+			const error = new Error( 'spawn failed' );
+			const commandPromise = runGitCommand( [ 'status' ] );
+
+			child.emit( 'error', error );
+
+			await expect( commandPromise ).rejects.toBe( error );
+		} );
+	} );
+} );
+
+function createMockChildProcess() {
+	const child = new EventEmitter();
+
+	child.stderr = new EventEmitter();
+	child.stdout = new EventEmitter();
+
+	return child;
+}


### PR DESCRIPTION
## Summary
- Harden internal git-related commands to execute through argv-based process spawning (`shell: false`) instead of interpolated shell strings.
- Keep `mrgit exec` shell-powered by design, but isolate that behavior from internal command execution and document it in the README.
- Add regression tests that pass shell-like payloads as arguments and verify they are treated as literal git arguments.
- Add a changelog entry for the fix.

Closes #216.

## Testing
- `pnpm lint lib/commands/exec.js lib/commands/diff.js lib/commands/push.js lib/commands/checkout.js lib/commands/close.js lib/commands/commit.js lib/commands/sync.js lib/utils/rungitcommand.js tests/commands/diff.js tests/commands/push.js tests/commands/checkout.js tests/commands/close.js tests/commands/commit.js tests/commands/sync.js README.md`
- `pnpm test`
- Reproduced the original PoC payload against `diff.execute(...)` and confirmed it now returns a git argument error instead of executing shell code.
- `ls HACKED` confirms no marker file is created.

## Context
- Related historical PR: #123