### PR TITLE
Fix npm OIDC token retrieval.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,9 @@ commands:
       - run:
           name: Get npm OIDC token
           command: |
-            echo "export NPM_ID_TOKEN=$(circleci run oidc get \
-              --claims '{\"aud\":\"npm:registry.npmjs.org\"}')" >> "$BASH_ENV"
+            NPM_ID_TOKEN=$(circleci run oidc get \
+              --claims '{"aud":"npm:registry.npmjs.org"}')
+            printf 'export NPM_ID_TOKEN=%q\n' "$NPM_ID_TOKEN" >> "$BASH_ENV"
 
   gpg_credentials_command:
     description: "Setup GPG configuration"


### PR DESCRIPTION
### 🚀 Summary

Fixes the CircleCI npm OIDC token step by passing valid, unescaped claims JSON.

The token retrieval now runs as a standalone assignment, ensuring that a failed `circleci run oidc get` command fails the CI step instead of being masked by a successful `echo`.

---

### 📌 Related issues

* See ckeditor/ckeditor5-internal#4615.

---

### 💡 Additional information

The YAML-expanded shell command was tested locally against strict success and failure mocks. A real OIDC token can only be requested within CircleCI.