### PR TITLE
Install npm with CircleCI OIDC support.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,9 @@ commands:
     description: "Enable publishing to `npm` using OIDC"
     steps:
       - run:
+          name: Install npm with CircleCI OIDC support
+          command: sudo npm i -g npm@^11.11.0
+      - run:
           name: Get npm OIDC token
           command: |
             NPM_ID_TOKEN=$(circleci run oidc get \


### PR DESCRIPTION
### 🚀 Summary

Installs npm `^11.11.0` before obtaining the npm OIDC token in the CircleCI release job.

The `cimg/node:24.11.0` image provides an older npm version whose OIDC implementation recognizes only GitHub Actions and GitLab. CircleCI support was added in npm/cli#8925 and first released in npm 11.11.0. Without this upgrade, npm ignores `NPM_ID_TOKEN` and attempts an unauthenticated publish.

---

### 📌 Related issues

* See ckeditor/ckeditor5-internal#4615.
* See ckeditor/ckeditor5-internal#4618.

---

### 💡 Additional information

This is an internal release configuration fix, so no changelog entry is required. ESLint, 3 script tests, 217 unit tests, YAML parsing, release package preparation, and `git diff --check` pass.