### PR TITLE
Add GitHub SSH host key.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,11 @@ commands:
       - add_ssh_keys:
           fingerprints:
             - "a0:41:a2:56:c8:7d:3f:29:41:d1:87:92:fd:50:2b:6b"
+      - run:
+          name: Add GitHub to known hosts
+          command: >-
+            printf '%s\n' 'github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl'
+            >> ~/.ssh/known_hosts
 
   npm_oidc_command:
     description: "Enable publishing to `npm` using OIDC"


### PR DESCRIPTION
### 🚀 Summary

Adds GitHub's published Ed25519 host key to `~/.ssh/known_hosts` after CircleCI installs the release SSH key.

The v5.0.0 package was published successfully, but the release job blocked while pushing the release commit because the GitHub App checkout had not established GitHub as a known SSH host. Pinning the documented key keeps host verification enabled while preventing the interactive confirmation prompt.

The key resolves to GitHub's published fingerprint: `SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU`.

---

### 📌 Related issues

* See ckeditor/ckeditor5-internal#4615.
* See ckeditor/ckeditor5-internal#4618.

---

### 💡 Additional information

This is an internal release configuration fix, so no changelog entry is required. The pinned key fingerprint, YAML parsing, ESLint, 3 script tests, 217 unit tests, release package preparation, and `git diff --check` were verified.