### PR TITLE
Add CODEOWNERS file to define repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+/.github/                            @cksource/ckeditor-5-platform
+/.circleci/                          @cksource/ckeditor-5-platform
+/lib/                                @cksource/ckeditor-5-platform
+/scripts/                            @cksource/ckeditor-5-platform
+/package.json                        @cksource/ckeditor-5-platform
+/pnpm-lock.yaml                      @cksource/ckeditor-5-platform
+/pnpm-workspace.yaml                 @cksource/ckeditor-5-platform


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Added CODEOWNERS file to define repository ownership.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Part of https://github.com/ckeditor/ckeditor5-internal/issues/4647.

---

### 💡 Additional information

- `@cksource/ckeditor-5-platform` with the `write` access is already added in this repository.
- Created new ruleset for code owners.

   <img width="1173" height="3402" alt="obraz" src="https://github.com/user-attachments/assets/3e72820a-ddb0-4ca9-8284-9e06abca0009" />

